### PR TITLE
using MS library for command line parsing

### DIFF
--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -48,26 +48,50 @@ namespace azmi_commandline
 
 
             //
+            // getblob
+            //
+
+            var getBlobCommand = new Command("getblob", "Downloads storage account blob to local file.");
+
+            var getBlob_blobOption = new Option(new String[] { "--blob", "-b" })
+            {
+                Argument = new Argument<String>("string"),
+                Description = "URL of blob which will be downloaded. Example: https://myaccount.blob.core.windows.net/mycontainer/myblob",
+                Required = true
+            };
+            getBlobCommand.AddOption(getBlob_blobOption);
+
+            var getBlob_FileOption = new Option(new String[] { "--file", "-f" })
+            {
+                Argument = new Argument<String>("string"),
+                Description = "Path to local file to which content will be downloaded. Examples: /tmp/1.txt, ./1.xml",
+                Required = true,
+            };
+            getBlobCommand.AddOption(getBlob_FileOption);
+            rootCommand.AddCommand(getBlobCommand);
+
+
+            //
             // setblob
             //
 
             var setBlobCommand = new Command("setblob", "Write local file to storage account blob.");
 
-            var fileOption = new Option(new String[] { "--file", "-f" })
+            var setBlob_fileOption = new Option(new String[] { "--file", "-f" })
             {
                 Argument = new Argument<String>("string"),
                 Description = "Path to local file which will be uploaded. Examples: /tmp/1.txt, ./1.xml",
                 Required = true,
             };
-            setBlobCommand.AddOption(fileOption);
+            setBlobCommand.AddOption(setBlob_fileOption);
 
-            var containerOption = new Option(new String[] { "--container", "-c" })
+            var setBlob_containerOption = new Option(new String[] { "--container", "-c" })
             {
                 Argument = new Argument<String>("string"),
                 Description = "URL of container to which file will be uploaded. Example: https://myaccount.blob.core.windows.net/mycontainer",
                 Required = true
             };
-            setBlobCommand.AddOption(containerOption);
+            setBlobCommand.AddOption(setBlob_containerOption);
             rootCommand.AddCommand(setBlobCommand);
 
 
@@ -84,11 +108,24 @@ namespace azmi_commandline
                 }
             });
 
+            getBlobCommand.Handler = CommandHandler.Create<string, string>((blob, file) =>
+            {
+                try
+                {
+                    Console.WriteLine(Operations.getBlob(blob, file));
+                } catch (Exception ex)
+                {
+                    DisplayError("getblob", ex);
+                }
+            });
+
             setBlobCommand.Handler = CommandHandler.Create<string, string>((file, container) =>
             {
-                try {
+                try
+                {
                     Console.WriteLine(Operations.setBlob(file, container));
-                } catch (Exception ex) {
+                } catch (Exception ex)
+                {
                     DisplayError("setblob", ex);
                 }
             });

--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -27,7 +27,7 @@ namespace azmi_commandline
             var rootCommand = new RootCommand()
             {
                 Description = "Command-line utility azmi stands for Azure Managed Identity.\n" +
-                    "It is helping admins simplify common operations (reading / writing) on Azure resources.\n" +
+                    "It is helping admins simplify common operations (reading and writing) on Azure resources.\n" +
                     "It is utilizing Azure AD authentication via user assigned managed identity.",
             };
 
@@ -80,7 +80,7 @@ namespace azmi_commandline
                 try {
                     Console.WriteLine(Operations.getToken());
                 } catch (Exception ex) {
-                    DisplayError(ex);
+                    DisplayError("gettoken", ex);
                 }
             });
 
@@ -89,7 +89,7 @@ namespace azmi_commandline
                 try {
                     Console.WriteLine(Operations.setBlob(file, container));
                 } catch (Exception ex) {
-                    DisplayError(ex);
+                    DisplayError("setblob", ex);
                 }
             });
 
@@ -97,9 +97,12 @@ namespace azmi_commandline
             return rootCommand;
         }
 
-        private static void DisplayError(Exception ex)
+        private static void DisplayError(string subCommand, Exception ex)
         {
-            Console.Error.WriteLine($"azmi setblob: {ex.Message}");
+            var oldColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine($"azmi {subCommand}: {ex.Message}");
+            Console.ForegroundColor = oldColor;
             Environment.Exit(2);
             // invocation returns exit code 2, parser errors will return exit code 1
         }

--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -1,129 +1,107 @@
 ﻿using azmi_main;
 using System;
-using System.Linq;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 
 namespace azmi_commandline
 {
+
     class Program
     {
         static void Main(string[] args)
         {
-            if (args.Length == 0)
-            {
-                // display usage and error
-                WriteLines(HelpMessage.application());
-                Environment.Exit(1);
-
-            }
-            else if (args[0] == "help")
-            {
-                // display usage
-                WriteLines(HelpMessage.application());
-                Environment.Exit(0);
-            }
-            else if (args.Length == 2 && args[1] == "help")
-            {
-                string invokeSubCommand = args[0];
-                if (HelpMessage.supportedSubCommands.Contains(invokeSubCommand))
-                {
-                    // Command specific help. like "azmi 0:setblob 1:help"
-                    WriteLines(HelpMessage.subCommand(invokeSubCommand));
-                }
-                else
-                {
-                    WriteLines($"Unrecognized subcommand '{invokeSubCommand}'.");
-                    // display usage and error
-                    WriteLines(HelpMessage.application());
-                    Environment.Exit(1);
-                }
-            }
-            else if (args[0] == "setblob")
-            {
-                //
-                // set blob subcommand
-                // azmi setblob $BLOB $FILE
-                //
-                if (args.Length != 3)
-                {
-                    // required parameters error, display setblob usage                    
-                    WriteLines(HelpMessage.subCommand("setblob"));
-                    Environment.Exit(1);
-                }
-                else
-                {
-                    try
-                    {
-                        // call setblob method
-                        WriteLines(Operations.setBlob(args[1], args[2]));
-                    }
-                    catch (System.IO.FileNotFoundException ex)
-                    {
-                        Console.WriteLine("Error: {0}", ex.Message);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine("General Error: {0}", ex.Message);
-                    }
-                }
-                // end of setblob command
-            }
-            else if (args[0] == "gettoken")
-            {
-                //
-                // get token subcommand
-                // azmi gettoken [$ENDPOINT]
-                //
-                if (args.Length == 1)
-                {                    
-                    try
-                    {
-                        // returns token obtained from default endpoint
-                        WriteLines(Operations.getToken());
-                    }                   
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine("General error: {0}", ex.Message);
-                    }
-                }
-                else if (args.Length == 2)
-                { // we have already covered option azmi gettoken help
-                    try
-                    {
-                        WriteLines(Operations.getToken(args[1]));
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine("General Error: {0}", ex.Message);
-                    }
-                }
-                else if (args.Length != 2)
-                {
-                    // parameters error, display setblob usage                    
-                    WriteLines(HelpMessage.subCommand("gettoken"));
-                    Environment.Exit(1);
-                }
-
-            }
-            //
-            // add here additional commands
-            //
-            else
-            {
-                // error unrecognized command
-                WriteLines("Error: Unrecognized command(s).");
-                WriteLines(HelpMessage.application());                
-                Environment.Exit(1);
-            }            
+            var rootCommand = ConfigureArguments();
+            var parseResult = rootCommand.Invoke(args);
+            Environment.Exit(parseResult);            
         }
 
-        private static void WriteLines(string[] s)
+
+        static RootCommand ConfigureArguments()
         {
-            foreach (var s1 in s) { Console.WriteLine(s1); };
+
+            //
+            // Create subcommands
+            // using nuget from https://github.com/dotnet/command-line-api
+            //
+
+            var rootCommand = new RootCommand()
+            {
+                Description = "Command-line utility azmi stands for Azure Managed Identity.\n" +
+                    "It is helping admins simplify common operations (reading / writing) on Azure resources.\n" +
+                    "It is utilizing Azure AD authentication via user assigned managed identity.",
+            };
+
+
+            //
+            // gettoken
+            //
+
+            var getTokenCommand = new Command("gettoken", "Obtain Azure authorization token.");
+            var endpointOption = new Option(new String[] { "--endpoint", "-e" })
+            {
+                Argument = new Argument<String>("string"),
+                Description = "Optional. Endpoint against which to authenticate. Examples: management, storage. Default 'management'",
+                Required = false
+            };
+            getTokenCommand.AddOption(endpointOption);
+            rootCommand.AddCommand(getTokenCommand);
+
+
+            //
+            // setblob
+            //
+
+            var setBlobCommand = new Command("setblob", "Write local file to storage account blob.");
+
+            var fileOption = new Option(new String[] { "--file", "-f" })
+            {
+                Argument = new Argument<String>("string"),
+                Description = "Path to local file which will be uploaded. Examples: /tmp/1.txt, ./1.xml",
+                Required = true,
+            };
+            setBlobCommand.AddOption(fileOption);
+
+            var containerOption = new Option(new String[] { "--container", "-c" })
+            {
+                Argument = new Argument<String>("string"),
+                Description = "URL of container to which file will be uploaded. Example: https://myaccount.blob.core.windows.net/mycontainer",
+                Required = true
+            };
+            setBlobCommand.AddOption(containerOption);
+            rootCommand.AddCommand(setBlobCommand);
+
+
+            //
+            // define actual subcommand handlers
+            //
+
+            getTokenCommand.Handler = CommandHandler.Create<string>((endpoint) =>
+            {
+                try {
+                    Console.WriteLine(Operations.getToken());
+                } catch (Exception ex) {
+                    DisplayError(ex);
+                }
+            });
+
+            setBlobCommand.Handler = CommandHandler.Create<string, string>((file, container) =>
+            {
+                try {
+                    Console.WriteLine(Operations.setBlob(file, container));
+                } catch (Exception ex) {
+                    DisplayError(ex);
+                }
+            });
+
+            // return generated command
+            return rootCommand;
         }
 
-        private static void WriteLines(string s)
+        private static void DisplayError(Exception ex)
         {
-            Console.WriteLine(s);
+            Console.Error.WriteLine($"azmi setblob: {ex.Message}");
+            Environment.Exit(2);
+            // invocation returns exit code 2, parser errors will return exit code 1
         }
     }
 }

--- a/src/azmi-commandline/azmi-commandline.csproj
+++ b/src/azmi-commandline/azmi-commandline.csproj
@@ -7,11 +7,20 @@
     <AssemblyName>azmi</AssemblyName>
     <ApplicationIcon />
     <Win32Resource />
+    <Version>0.2.0</Version>
+    <Company>Microsoft</Company>
+    <Description>Command-line utility azmi stands for Azure Managed Identity.
+It is helping admins simplify common operations (reading / writing) on standard Azure resources.
+It is utilizing Azure AD authentication via user assigned managed identity.</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19577.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\azmi-main\azmi-main.csproj" />

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -35,9 +35,18 @@ test "Check all dependencies are installed" assert.Success "dpkg -s libstdc++6"
 install_azmi
 test "Verify azmi binary exists and is executable" assert.Success "[ -x /usr/bin/azmi ]"
 
-testing class "application"
-test "Print help and return success status" assert.Success "azmi help"
 
+testing class "help"
+test "Should fail if no arguments are provided" asser.Fail "azmi"
+test "Print help and return success status" assert.Success "azmi --help"
+test "Print help for gettoken" assert.Success "azmi gettoken --help"
+test "Fail gettoken with wrong args" assert.Fail "azmi gettoken blahblah"
+test "Print help for setblob" assert.Success "azmi setblob --help"
+test "Fail setblob with wrong args" assert.Fail "azmi setblob blahblah"
+# TODO Automate above using list of supported subcommands
+
+
+testing class "application"
 # e.g. 2020-01-07_14:41:02
 TIMESTAMP=`date "+%Y-%m-%d_%H:%M:%S"`
 RANDOM_BLOB_TO_STORE="/tmp/azmi_integration_test_${TIMESTAMP}.txt"


### PR DESCRIPTION
Completely rewritten command line class in order to utilize Microsoft's library `System.CommandLine` (Github repo https://github.com/dotnet/command-line-api). Resolves #22 

Major changes:
- help switches require -- in front
  it is now `azmi --help` and not just `azmi help` _(tests updated)_
- subcommands require argument names in front of argument values because the library has no support for positional parameters **_(not updated in tests!)_**
  it is now `azmi gettoken --endpoint storage`
  argument short names can be used also, i.e. instead of --endpoint, one can use just `-e`
- **(new functionality)** application is now returning non-zero exit codes **_(not updated in tests!)_**
  exit code 1 - parser errors
  exit code 2 - subcommand invocation error (with short message displayed)

ToDo before merge:
- [x] - resolve conflicts in `azmi-commandline.cs`
- [x] - integrate getblob into this PR
- [x] - update integration test with argument names
- [x] - check for failure codes from operations in integration tests