### PR TITLE
adding verbose option for error display

### DIFF
--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -97,6 +97,12 @@ test "Prepare tmp file" assert.Success "rm -f /tmp/${RANDOM_BLOB_TO_STORE} && ec
 test "Upload tmp file" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --container ${CONTAINER_URL}"
 test "There is no noname folder after upload" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_URL}//tmp/${RANDOM_BLOB_TO_STORE}"
 
+# it should support verbose option for commands
+testing class "verbose"
+test "gettoken verbose option" assert.Success "azmi gettoken --help | grep verbose"
+test "getblob verbose option" assert.Success "azmi getblob --help | grep verbose"
+test "setblob verbose option" assert.Success "azmi setblob --help | grep verbose"
+
 # uninstalling
 testing class "package"
 test "Uninstall packages" assert.Success "apt purge $PACKAGENAME -y"


### PR DESCRIPTION
In the future (#28) this will be added for command output also. For now, just error display is more verbose.

Resolves #46 