### PR TITLE
Setblob byblob

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ azmi getblob --blob $BLOB_URL --file $FILE
 
 # upload file as a blob to storage account container
 azmi setblob --file $FILE --container $CONTAINER_URL
+
+# upload file by specifying blob url and identity
+azmi setblob --file ~/info.txt --blob $CONTAINER_URL/myhostname/info.txt --identity 117dc05c-4d12-4ac2-b5f8-5e239dc8bc54
 ```
 
 ## Download

--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -112,6 +112,7 @@ namespace azmi_commandline
                 Required = false
             };
             setBlobCommand.AddOption(setBlob_containerOption);
+            setBlobCommand.AddOption(setBlob_blobOption);
             setBlobCommand.AddOption(shared_identityOption);
             setBlobCommand.AddOption(shared_verboseOption);
 

--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -148,25 +148,22 @@ namespace azmi_commandline
             {
                 if (blob == null && container == null)
                 {
-                    throw new ArgumentNullException("blob, container", "You must specify either blob or container url");
-                } else if (blob != null && container != null)
+                    throw new ArgumentException("You must specify either blob or container url");
+                }
+                else if (blob != null && container != null)
                 {
                     throw new ArgumentException("Cannot use both container and blob url");
-                } else
+                } 
+
+                try
                 {
-                    try
-                    {
-                        if (container != null)
-                        {
-                            Console.WriteLine(Operations.setBlob_byContainer(file, container, identity));
-                        } else
-                        {
-                            Console.WriteLine(Operations.setBlob_byBlob(file, blob, identity));
-                        }                        
-                    } catch (Exception ex)
-                    {
-                        DisplayError("setblob", ex, verbose);
-                    }
+                    Console.WriteLine(container != null
+                        ? Operations.setBlob_byContainer(file, container, identity)
+                        : Operations.setBlob_byBlob(file, blob, identity)
+                        );
+                } catch (Exception ex)
+                {
+                    DisplayError("setblob", ex, verbose);
                 }
             });
 

--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -102,8 +102,14 @@ namespace azmi_commandline
             var setBlob_containerOption = new Option(new String[] { "--container", "-c" })
             {
                 Argument = new Argument<String>("string"),
-                Description = "URL of container to which file will be uploaded. Example: https://myaccount.blob.core.windows.net/mycontainer",
-                Required = true
+                Description = "URL of container to which file will be uploaded. Cannot be used together with --blob. Example: https://myaccount.blob.core.windows.net/mycontainer",
+                Required = false
+            };
+            var setBlob_blobOption = new Option(new String[] { "--blob", "-b" })
+            {
+                Argument = new Argument<String>("string"),
+                Description = "URL of blob to which file will be uploaded. Cannot be used together with --container. Example: https://myaccount.blob.core.windows.net/mycontainer/myblob.txt",
+                Required = false
             };
             setBlobCommand.AddOption(setBlob_containerOption);
             setBlobCommand.AddOption(shared_identityOption);
@@ -137,14 +143,29 @@ namespace azmi_commandline
                 }
             });
 
-            setBlobCommand.Handler = CommandHandler.Create<string, string, string, bool>((file, container, identity, verbose) =>
+            setBlobCommand.Handler = CommandHandler.Create<string, string, string, string, bool>((file, blob, container, identity, verbose) =>
             {
-                try
+                if (blob == null && container == null)
                 {
-                    Console.WriteLine(Operations.setBlob(file, container, identity));
-                } catch (Exception ex)
+                    throw new ArgumentNullException("blob, container", "You must specify either blob or container url");
+                } else if (blob != null && container != null)
                 {
-                    DisplayError("setblob", ex, verbose);
+                    throw new ArgumentException("Cannot use both container and blob url");
+                } else
+                {
+                    try
+                    {
+                        if (container != null)
+                        {
+                            Console.WriteLine(Operations.setBlob_byContainer(file, container, identity));
+                        } else
+                        {
+                            Console.WriteLine(Operations.setBlob_byBlob(file, blob, identity));
+                        }                        
+                    } catch (Exception ex)
+                    {
+                        DisplayError("setblob", ex, verbose);
+                    }
                 }
             });
 

--- a/src/azmi-commandline/azmi-commandline.cs
+++ b/src/azmi-commandline/azmi-commandline.cs
@@ -146,11 +146,11 @@ namespace azmi_commandline
 
             setBlobCommand.Handler = CommandHandler.Create<string, string, string, string, bool>((file, blob, container, identity, verbose) =>
             {
-                if (blob == null && container == null)
+                if (String.IsNullOrEmpty(blob) && String.IsNullOrEmpty(container))
                 {
                     throw new ArgumentException("You must specify either blob or container url");
                 }
-                else if (blob != null && container != null)
+                else if ( (!String.IsNullOrEmpty(blob)) && (!String.IsNullOrEmpty(container)))
                 {
                     throw new ArgumentException("Cannot use both container and blob url");
                 } 

--- a/src/azmi-main/Operations.cs
+++ b/src/azmi-main/Operations.cs
@@ -57,9 +57,9 @@ namespace azmi_main
             }
         }
 
-        public static string setBlob(string filePath, string containerUri, string identity = null)
+        public static string setBlob_byContainer(string filePath, string containerUri, string identity = null)
         {
-            // sets blob content based on local file content
+            // sets blob content based on local file content in provided container
             if (!(File.Exists(filePath))) {
                 throw new FileNotFoundException($"File '{filePath}' not found!");
             }
@@ -77,5 +77,25 @@ namespace azmi_main
                 throw IdentityError(identity, ex);
             }
         }
+        public static string setBlob_byBlob(string filePath, string blobUri, string identity = null)
+        {
+            // sets blob content based on local file content with provided blob url
+            if (!(File.Exists(filePath)))
+            {
+                throw new FileNotFoundException($"File '{filePath}' not found!");
+            }
+
+            var Cred = new ManagedIdentityCredential(identity);
+            var blobClient = new BlobClient(new Uri(blobUri), Cred);
+            try
+            {
+                blobClient.Upload(filePath);
+                return "Success";
+            } catch (Exception ex)
+            {
+                throw IdentityError(identity, ex);
+            }
+        }
+
     }
 }

--- a/test/azmi-main-tests/OperationsTests.cs
+++ b/test/azmi-main-tests/OperationsTests.cs
@@ -31,7 +31,7 @@ namespace azmi_tests
         [Fact]
         public void setBlob_failsIfNoLocalFile()
         {
-            var ex = Assert.Throws<FileNotFoundException>(() => Operations.setBlob("nonexistingfile", "blobdoesnotmatter"));
+            var ex = Assert.Throws<FileNotFoundException>(() => Operations.setBlob_byContainer("nonexistingfile", "blobdoesnotmatter"));
             Assert.Equal("File 'nonexistingfile' not found!", ex.Message);
         }
 
@@ -41,7 +41,7 @@ namespace azmi_tests
             // TODO: Check for proper exception message
             var tempFile = Path.GetTempFileName();
             File.Create(tempFile).Close();
-            Assert.ThrowsAny<Exception>(() => Operations.setBlob(tempFile, "blobdoesnotmatter"));
+            Assert.ThrowsAny<Exception>(() => Operations.setBlob_byContainer(tempFile, "blobdoesnotmatter"));
             File.Delete(tempFile);
         }
     }

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -99,7 +99,7 @@ test "There is no noname folder after upload" assert.Fail "azmi getblob -f /dev/
 
 # testing setblob-byblob 
 testing class "setblob-byblob"
-test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_URL}/byblob/${RANDOM_BLOB_TO_STORE}.txt"
+test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_URL}/byblob/${RANDOM_BLOB_TO_STORE}"
 
 # it should support verbose option for commands
 testing class "verbose"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -97,6 +97,10 @@ test "Prepare tmp file" assert.Success "rm -f /tmp/${RANDOM_BLOB_TO_STORE} && ec
 test "Upload tmp file" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --container ${CONTAINER_URL}"
 test "There is no noname folder after upload" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_URL}//tmp/${RANDOM_BLOB_TO_STORE}"
 
+# testing setblob-byblob 
+testing class "setblob-byblob"
+test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_URL}/byblob/${RANDOM_BLOB_TO_STORE}.txt"
+
 # it should support verbose option for commands
 testing class "verbose"
 test "gettoken verbose option" assert.Success "azmi gettoken --help | grep verbose"


### PR DESCRIPTION
Code changes:

**`commandline.cs`**
- add new argument for `setblob` command named `--blob`, both blob and container are now optional
- `setblob` handler updated to call different methods if there is `blob` or `container` argument

**`readme.md`**
- added new example with this new functionality and also with identity argument 
_(maybe we can open new page for examples and just drop bunch of them there?)_

**`Operations.cs`**
- renamed original `setBlob` method to `setBlob_byContainer` _(done also in tests)_
- added new method `setBlob_byBlob` which created `blobClient` based on provided blobUri

**`integration_test.sh`**
- added new test like `azmi setblob -f $FILE --blob $CONTAINER/mydir/$FILE


Resolves #50 
Resolves #45 