### PR TITLE
Redo integration

### DIFF
--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -89,7 +89,8 @@ test "setblob fails to overwrite on blob" assert.Fail "azmi setblob -f $UPLOADFI
 test "setblob overwrites blob on container" assert.Success "azmi setblob -f $UPLOADFILE --container $CONTAINER_RW --force"
 test "setblob overwrites blob on blob" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 
-testing class "SHA256"3# it is using the file uploaded in previous step
+testing class "SHA256"
+test "setblob SHA256 upload" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 test "getblob SHA256 download" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE"
 test "SHA256 same contents" assert.Success "diff $UPLOADFILE $DOWNLOAD_FILE"
 UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -8,7 +8,7 @@
 # setup variables
 #
 
-# TODO: remove these two from script, or change it to $1, $2
+# this script is called from testing framework script, therefore arguments are shifted
 STORAGEACCOUNTNAME=$2
 identity=$3
 
@@ -20,10 +20,6 @@ declare -a subCommands=("gettoken" "getblob" "getblobs" "setblob" "listblobs")
 identity_foreign=017dc05c-4d12-4ac2-b5f8-5e239dc8bc54
 
 # calculated variables
-CONTAINER_NA="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-no-access"
-CONTAINER_RO="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-r"
-CONTAINER_RW="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-rw"
-CONTAINER_LB="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-listblobs"
 
 
 #
@@ -54,13 +50,18 @@ done
 
 testing class "gettoken"
 
-test "get access token" assert.Success "azmi gettoken"
-test "get access token in JWT format" assert.Success "azmi gettoken --jwt-format | grep typ | grep JWT"
-
+test "gettoken basic" assert.Success "azmi gettoken"
+test "gettoken in JWT format" assert.Success "azmi gettoken --jwt-format | grep typ | grep JWT"
+test "gettoken fails with wrong args" assert.Fail "azmi gettoken blahblah"
 
 #
 # storage subcommands testing
 #
+
+CONTAINER_NA="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-no-access"
+CONTAINER_RO="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-r"
+CONTAINER_RW="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-rw"
+CONTAINER_LB="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-listblobs"
 
 BLOB_NA="restricted_access_blob.txt"
 BLOB_RO="read_only_blob.txt"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -66,25 +66,21 @@ test "get access token in JWT format" assert.Success "azmi gettoken --jwt-format
 
 testing class "getblob"
 ### no-access container ###
-BLOB="restricted_access_blob.txt"
-test "Fails to read from NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB --file download.txt"
-test "Fails to save to NA container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_NA"
+BLOB_NA="restricted_access_blob.txt"
+BLOB_RO="read_only_blob.txt"
 
-### read-only container ###
-# Role(s):    Storage Blob Data Reader
-# Profile(s): bt-seu-test-id (obj. ID: d1c05b65-ccf9-47bd-870d-4e44d209ee7a), kotipoiss-identity (obj. ID: ccb781af-a4eb-4ecc-b183-cef74b3cc717)
-BLOB="read_only_blob.txt"
-test "Read blob contents from RO container" assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt"
-test "Fails to save to RO container" assert.Fail "azmi setblob --file download.txt --container $CONTAINER_RO"
+test "getblob fails on NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB_NA --file download.txt"
+test "getblob OK on RO container" assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt"
 # test --identity options
-test "Read blob from RO container using right identity"                 assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt --identity $identity"
-test "Fails to read blob from RO container using foreign identity"      assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt --identity $identity_foreign"
-test "Fails to read blob from RO container using non-existing identity" assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt --identity non-existing"
+test "getblob OK on RO container using right identity"           assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity"
+test "getblob fails on RO container using foreign identity"      assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity_foreign"
+test "getblob fails on RO container using non-existing identity" assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity non-existing"
 
-### read-write container ###
-# Role(s):    Storage Blob Data Contributor
-# Profile(s): bt-seu-test-id (obj. ID: d1c05b65-ccf9-47bd-870d-4e44d209ee7a), kotipoiss-identity (obj. ID: ccb781af-a4eb-4ecc-b183-cef74b3cc717)
-test "Save file contents   to RW container" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
+testing class "setblob"
+test "setblob fails on NA container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_NA"
+test "setblob fails on RO container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_RO"
+test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
+
 DOWNLOADED_BLOB="azmi_itest_downloaded.txt"
 test "Read blob contents from RW container" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOADED_BLOB"
 test "Blobs have to have same contents" assert.Success "diff $UPLOADFILE $DOWNLOADED_BLOB"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -64,18 +64,17 @@ test "get access token in JWT format" assert.Success "azmi gettoken --jwt-format
 # storage subcommands testing
 #
 
-
-testing class "getblob"
-### no-access container ###
 BLOB_NA="restricted_access_blob.txt"
 BLOB_RO="read_only_blob.txt"
+DOWNLOAD_FILE="download.txt"
 
-test "getblob fails on NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB_NA --file download.txt"
-test "getblob OK on RO container" assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt"
+testing class "getblob"
+test "getblob fails on NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB_NA --file $DOWNLOAD_FILE"
+test "getblob OK on RO container" assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file $DOWNLOAD_FILE"
 # test --identity options
-test "getblob OK on RO container using right identity"           assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity"
-test "getblob fails on RO container using foreign identity"      assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity_foreign"
-test "getblob fails on RO container using non-existing identity" assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity non-existing"
+test "getblob OK on RO container using right identity"        assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity"
+test "getblob fails on RO container using foreign identity"      assert.Fail "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity_foreign"
+test "getblob fails on RO container using non-existing identity" assert.Fail "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity non-existing"
 
 
 testing class "setblob"
@@ -84,14 +83,16 @@ test "setblob fails on RO container" assert.Fail "azmi setblob --file $UPLOADFIL
 test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
 
 
+testing class "SHA256"
+test "setblob SHA256 upload" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
+test "getblob SHA256 download" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE"
+test "SHA256 same contents" assert.Success "diff $UPLOADFILE $DOWNLOAD_FILE"
+UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
+DOWNLOADFILE_SHA256=$(sha256sum $DOWNLOAD_FILE | awk '{ print $1 }')
+test "SHA256 same checksums" assert.Success "[ $UPLOADFILE_SHA256 = $DOWNLOADFILE_SHA256 ]"
+
 # TODO: IGOR TAGGED: PROCEED FROM HERE
 
-DOWNLOADED_BLOB="azmi_itest_downloaded.txt"
-test "Read blob contents from RW container" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOADED_BLOB"
-test "Blobs have to have same contents" assert.Success "diff $UPLOADFILE $DOWNLOADED_BLOB"
-UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
-DOWNLOADED_BLOB_SHA256=$(sha256sum $DOWNLOADED_BLOB | awk '{ print $1 }')
-test "Blobs have to have equal SHA256 checksums" assert.Success "[ $UPLOADFILE_SHA256 = $DOWNLOADED_BLOB_SHA256 ]"
 
 # there should be no <noname> folder in Azure
 testing class "noname"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -88,8 +88,7 @@ test "setblob fails to overwrite on blob" assert.Fail "azmi setblob -f $UPLOADFI
 test "setblob overwrites blob on container" assert.Success "azmi setblob -f $UPLOADFILE --container $CONTAINER_RW --force"
 test "setblob overwrites blob on blob" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 
-testing class "SHA256"
-# it is using the file uploaded in previous step
+testing class "SHA256"3# it is using the file uploaded in previous step
 test "getblob SHA256 download" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE"
 test "SHA256 same contents" assert.Success "diff $UPLOADFILE $DOWNLOAD_FILE"
 UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
@@ -106,7 +105,7 @@ testing class "listblobs"
 BC=5 # blob count
 test "listblobs basic" assert.Success "azmi listblobs --container $CONTAINER_LB"
 test "listblobs finds $BC blobs" assert.Equals "azmi listblobs --container $CONTAINER_LB | wc -l" $BC
-BC=5; PREFIX="neu-pre"
+BC=3; PREFIX="neu-pre"
 test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC
 BC=1; PREFIX="neu-pre-show-me-only"
 test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -71,17 +71,22 @@ DOWNLOAD_FILE="download.txt"
 testing class "getblob"
 test "getblob fails on NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB_NA --file $DOWNLOAD_FILE"
 test "getblob OK on RO container" assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file $DOWNLOAD_FILE"
-# test --identity options
+
+testing class "getblob identity"
 test "getblob OK on RO container using right identity"        assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity"
 test "getblob fails on RO container using foreign identity"      assert.Fail "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity_foreign"
 test "getblob fails on RO container using non-existing identity" assert.Fail "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity non-existing"
-
 
 testing class "setblob"
 test "setblob fails on NA container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_NA"
 test "setblob fails on RO container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_RO"
 test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
 
+testing class "setblob force"
+test "setblob fails to overwrite on container" assert.Fail "azmi setblob -f $UPLOADFILE --container $CONTAINER_RW"
+test "setblob fails to overwrite on blob" assert.Fail "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE}"
+test "setblob overwrites blob on container" assert.Success "azmi setblob -f $UPLOADFILE --container $CONTAINER_RW --force"
+test "setblob overwrites blob on blob" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 
 testing class "SHA256"
 # it is using file uploaded in previous step
@@ -91,14 +96,13 @@ UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
 DOWNLOADFILE_SHA256=$(sha256sum $DOWNLOAD_FILE | awk '{ print $1 }')
 test "SHA256 same checksums" assert.Success "[ $UPLOADFILE_SHA256 = $DOWNLOADFILE_SHA256 ]"
 
-# TODO: IGOR TAGGED: PROCEED FROM HERE
-
-
-# there should be no <noname> folder in Azure
 testing class "noname"
-test "Prepare tmp file" assert.Success "rm -f /tmp/${UPLOADFILE} && echo sometext > /tmp/${UPLOADFILE}"
-test "Upload tmp file" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
-test "There is no noname folder after upload" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${UPLOADFILE}"
+test "prepare tmp file" assert.Success "rm -f /tmp/${UPLOADFILE} && echo sometext > /tmp/${UPLOADFILE}"
+test "upload tmp file" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
+test "there is no noname folder" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${UPLOADFILE}"
+
+
+# TODO: IGOR TAGGED: PROCEED FROM HERE
 
 testing class "listblobs"
 ### list-blobs container
@@ -133,12 +137,6 @@ test "We should successfully download $EXPECTED_BLOB_COUNT blobs with prefix '$P
 testing class "setblob-byblob"
 test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE}"
 
-# --force option
-testing class "--force option"
-test "Fails to attempt to overwrite existing blob using --container option" assert.Fail "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
-test "Fails to attempt to overwrite existing blob using --blob option" assert.Fail "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE}"
-test "Overwrite existing blob using --container option" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW} --force"
-test "Overwrite existing blob using --blob option" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE} --force"
 
 # --if-newer option
 testing class "--if-newer option"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -9,11 +9,8 @@
 #
 
 # TODO: remove these two from script, or change it to $1, $2
-STORAGEACCOUNTNAME=azmitest
-identity=354800af-354e-42e0-906b-5b96e02c4e1c
-echo "First argument: '$1'"
-echo "Second argument: '$2'"
-echo "Third argument: '$3'"
+STORAGEACCOUNTNAME=$2
+identity=$3
 
 
 export DEBIAN_FRONTEND=noninteractive

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -64,7 +64,7 @@ test "get access token in JWT format" assert.Success "azmi gettoken --jwt-format
 # storage subcommands testing
 #
 
-
+testing class "getblob"
 ### no-access container ###
 BLOB="restricted_access_blob.txt"
 test "Fails to read from NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB --file download.txt"
@@ -88,15 +88,15 @@ test "Save file contents   to RW container" assert.Success "azmi setblob --file 
 DOWNLOADED_BLOB="azmi_itest_downloaded.txt"
 test "Read blob contents from RW container" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOADED_BLOB"
 test "Blobs have to have same contents" assert.Success "diff $UPLOADFILE $DOWNLOADED_BLOB"
-UPLOADFILE_SHA256=$(sha256sum $UPLOADFILE | awk '{ print $1 }')
+UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
 DOWNLOADED_BLOB_SHA256=$(sha256sum $DOWNLOADED_BLOB | awk '{ print $1 }')
 test "Blobs have to have equal SHA256 checksums" assert.Success "[ $UPLOADFILE_SHA256 = $DOWNLOADED_BLOB_SHA256 ]"
 
 # there should be no <noname> folder in Azure
 testing class "noname"
-test "Prepare tmp file" assert.Success "rm -f /tmp/${RANDOM_BLOB_TO_STORE} && echo sometext > /tmp/${RANDOM_BLOB_TO_STORE}"
-test "Upload tmp file" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --container ${CONTAINER_RW}"
-test "There is no noname folder after upload" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${RANDOM_BLOB_TO_STORE}"
+test "Prepare tmp file" assert.Success "rm -f /tmp/${UPLOADFILE} && echo sometext > /tmp/${UPLOADFILE}"
+test "Upload tmp file" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
+test "There is no noname folder after upload" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${UPLOADFILE}"
 
 testing class "listblobs"
 ### list-blobs container
@@ -129,26 +129,26 @@ test "We should successfully download $EXPECTED_BLOB_COUNT blobs with prefix '$P
 
 # testing setblob-byblob 
 testing class "setblob-byblob"
-test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_RW}/byblob/${RANDOM_BLOB_TO_STORE}"
+test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE}"
 
 # --force option
 testing class "--force option"
-test "Fails to attempt to overwrite existing blob using --container option" assert.Fail "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --container ${CONTAINER_RW}"
-test "Fails to attempt to overwrite existing blob using --blob option" assert.Fail "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_RW}/byblob/${RANDOM_BLOB_TO_STORE}"
-test "Overwrite existing blob using --container option" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --container ${CONTAINER_RW} --force"
-test "Overwrite existing blob using --blob option" assert.Success "azmi setblob -f /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_RW}/byblob/${RANDOM_BLOB_TO_STORE} --force"
+test "Fails to attempt to overwrite existing blob using --container option" assert.Fail "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
+test "Fails to attempt to overwrite existing blob using --blob option" assert.Fail "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE}"
+test "Overwrite existing blob using --container option" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW} --force"
+test "Overwrite existing blob using --blob option" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE} --force"
 
 # --if-newer option
 testing class "--if-newer option"
 test "Should skip: Download blob and write to file only if difference has been spotted (--if-newer option)" assert.Equals \
-  "azmi getblob --blob ${CONTAINER_RW}/${RANDOM_BLOB_TO_STORE} --file /tmp/${RANDOM_BLOB_TO_STORE} --if-newer" "Skipped. Blob is not newer than file."
+  "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/${UPLOADFILE} --if-newer" "Skipped. Blob is not newer than file."
 sleep 1s
-test "Alter blob's modification time" assert.Success "azmi setblob --file /tmp/${RANDOM_BLOB_TO_STORE} --blob ${CONTAINER_RW}/${RANDOM_BLOB_TO_STORE} --force"
+test "Alter blob's modification time" assert.Success "azmi setblob --file /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 test "Download blob and write to file only if difference has been spotted (--if-newer option)" assert.Equals \
-  "azmi getblob --blob ${CONTAINER_RW}/${RANDOM_BLOB_TO_STORE} --file /tmp/${RANDOM_BLOB_TO_STORE} --if-newer" "Success"
-TIMESTAMP=`date "+%Y%m%d_%H%M%S"` # e.g. 20200107_144102
+  "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/${UPLOADFILE} --if-newer" "Success"
+TIMESTAMP=$(date "+%Y%m%d_%H%M%S") # e.g. 20200107_144102
 test "Download blob and write to file which does not exist yet (--if-newer option)" assert.Equals \
-  "azmi getblob --blob ${CONTAINER_RW}/${RANDOM_BLOB_TO_STORE} --file /tmp/unique-file.${TIMESTAMP} --if-newer" "Success"
+  "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/unique-file.${TIMESTAMP} --if-newer" "Success"
 
 # uninstalling
 testing class "package"
@@ -160,12 +160,12 @@ test "Verify azmi binary does not exist anymore" assert.Fail "[ -f /usr/bin/azmi
 #  Clean up actions
 #
 
-rm $UPLOADFILE
+rm "$UPLOADFILE"
 
 #################################
 # display some diagnostic data
 ################################
 echo -e "\n=============="
-echo "Test running at '`hostname`' host"
+echo "Test running at '$(hostname)' host"
 
 testing end

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -12,6 +12,7 @@ export DEBIAN_FRONTEND=noninteractive
 PACKAGENAME=azmi
 PACKAGEFILE=/tmp/azmiX.deb
 STORAGEACCOUNTNAME=azmitest
+declare -a subCommands=("gettoken" "getblob" "getblobs" "setblob" "listblobs")
 
 # calculated variables
 CONTAINER_NA="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-no-access"
@@ -34,7 +35,7 @@ testing class "help"
 test "Fail if no arguments are provided" assert.Fail "azmi"
 test "Print help and return success status" assert.Success "azmi --help"
 
-foreach subcommand (gettoken getblob setblob)
+for subCommand in "${subCommands[@]}"
   test "Print help for $subcommand" assert.Success "azmi $subcommand --help"
   test "Fail $subcommand with wrong args" assert.Fail "azmi $subcommand blahblah"
 end
@@ -49,7 +50,7 @@ end
 # TODO Automate above using list of supported subcommands
 
 
-testing class "application"
+testing class "gettoken"
 
 test "Authenticate to Azure using a managed identity and get access token" assert.Success "azmi gettoken"
 test "Authenticate to Azure using a managed identity and get access token in JWT format" assert.Success "azmi gettoken --jwt-format | grep typ | grep JWT"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -24,11 +24,6 @@ CONTAINER_RO="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-r"
 CONTAINER_RW="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-rw"
 CONTAINER_LB="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-listblobs"
 
-# prepare test upload file
-DATE1=$(date +%s)   # used in file name
-DATE2=$(date +%s%N) # used in file content
-UPLOADFILE="upload$DATE1.txt"
-echo "$DATE2" > "$UPLOADFILE"
 
 #
 # start testing
@@ -70,6 +65,12 @@ BLOB_NA="restricted_access_blob.txt"
 BLOB_RO="read_only_blob.txt"
 DOWNLOAD_FILE="download.txt"
 DOWNLOAD_DIR="./Download"
+# prepare test upload file
+DATE1=$(date +%s)   # used in file name
+DATE2=$(date +%s%N) # used in file content
+UPLOADFILE="upload$DATE1.txt"
+echo "$DATE2" > "$UPLOADFILE"
+
 
 testing class "getblob"
 test "getblob fails on NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB_NA --file $DOWNLOAD_FILE"
@@ -130,19 +131,17 @@ test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getb
 testing class "if-newer"
 SKIPMSG="Skipped. Blob is not newer than file."
 test "setblob prepares the file" assert.Equals "azmi setblob -f $UPLOADFILE -c $CONTAINER_RW"
+touch "$UPLOADFILE"
 test "getblob skips if not newer" assert.Equals "azmi getblob -b ${CONTAINER_RW}/${UPLOADFILE} -f $UPLOADFILE --if-newer" "$SKIPMSG"
-sleep 1s
 test "setblob updates blob" assert.Success "azmi setblob -f $UPLOADFILE -c $CONTAINER_RW --force"
+sleep 1
 test "getblob downloads if newer" assert.Equals "azmi getblob -b ${CONTAINER_RW}/${UPLOADFILE} -f $UPLOADFILE --if-newer" "Success"
 rm -rf $DOWNLOAD_FILE
 test "getblob downloads newer than nonexisting" assert.Equals "azmi getblob -b ${CONTAINER_RW}/${UPLOADFILE} -f $DOWNLOAD_FILE --if-newer" "Success"
 
-# TODO: IGOR TAGGED: PROCEED FROM HERE
-
 # uninstalling
 testing class "package"
 test "Uninstall packages" assert.Success "apt purge $PACKAGENAME -y"
-
 test "Verify azmi binary does not exist anymore" assert.Fail "[ -f /usr/bin/azmi ]"
 
 #
@@ -150,6 +149,7 @@ test "Verify azmi binary does not exist anymore" assert.Fail "[ -f /usr/bin/azmi
 #
 
 rm "$UPLOADFILE"
+rm -rf $DOWNLOAD_DIR
 
 #################################
 # display some diagnostic data

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -37,8 +37,9 @@ test "Print help and return success status" assert.Success "azmi --help"
 
 for subCommand in "${subCommands[@]}"
 do
-  test "Print help for $subcommand" assert.Success "azmi $subcommand --help"
-  test "Fail $subcommand with wrong args" assert.Fail "azmi $subcommand blahblah"
+  test "Print help for $subCommand" assert.Success "azmi $subCommand --help"
+  test "$subCommand verbose option" assert.Success "azmi $subCommand --help | grep verbose"
+  test "Fail $subCommand with wrong args" assert.Fail "azmi $subCommand blahblah"
 done
 # test "Print help for gettoken" assert.Success "azmi gettoken --help"
 # test "Fail gettoken with wrong args" assert.Fail "azmi gettoken blahblah"
@@ -49,6 +50,12 @@ done
 # test "Print help for setblob" assert.Success "azmi setblob --help"
 # test "Fail setblob with wrong args" assert.Fail "azmi setblob blahblah"
 # TODO Automate above using list of supported subcommands
+
+# it should support verbose option for commands
+# testing class "verbose"
+# test "gettoken verbose option" assert.Success "azmi gettoken --help | grep verbose"
+# test "getblob verbose option" assert.Success "azmi getblob --help | grep verbose"
+# test "setblob verbose option" assert.Success "azmi setblob --help | grep verbose"
 
 
 testing class "gettoken"
@@ -157,12 +164,6 @@ test "Download blob and write to file only if difference has been spotted (--if-
 TIMESTAMP=`date "+%Y%m%d_%H%M%S"` # e.g. 20200107_144102
 test "Download blob and write to file which does not exist yet (--if-newer option)" assert.Equals \
   "azmi getblob --blob ${CONTAINER_URL}/${RANDOM_BLOB_TO_STORE} --file /tmp/unique-file.${TIMESTAMP} --if-newer" "Success"
-
-# it should support verbose option for commands
-testing class "verbose"
-test "gettoken verbose option" assert.Success "azmi gettoken --help | grep verbose"
-test "getblob verbose option" assert.Success "azmi getblob --help | grep verbose"
-test "setblob verbose option" assert.Success "azmi setblob --help | grep verbose"
 
 # uninstalling
 testing class "package"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -84,7 +84,7 @@ test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFIL
 
 
 testing class "SHA256"
-test "setblob SHA256 upload" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
+# it is using file uploaded in previous step
 test "getblob SHA256 download" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE"
 test "SHA256 same contents" assert.Success "diff $UPLOADFILE $DOWNLOAD_FILE"
 UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -36,9 +36,10 @@ test "Fail if no arguments are provided" assert.Fail "azmi"
 test "Print help and return success status" assert.Success "azmi --help"
 
 for subCommand in "${subCommands[@]}"
+do
   test "Print help for $subcommand" assert.Success "azmi $subcommand --help"
   test "Fail $subcommand with wrong args" assert.Fail "azmi $subcommand blahblah"
-end
+done
 # test "Print help for gettoken" assert.Success "azmi gettoken --help"
 # test "Fail gettoken with wrong args" assert.Fail "azmi gettoken blahblah"
 

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -64,6 +64,7 @@ test "get access token in JWT format" assert.Success "azmi gettoken --jwt-format
 # storage subcommands testing
 #
 
+
 testing class "getblob"
 ### no-access container ###
 BLOB_NA="restricted_access_blob.txt"
@@ -76,10 +77,14 @@ test "getblob OK on RO container using right identity"           assert.Success 
 test "getblob fails on RO container using foreign identity"      assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity $identity_foreign"
 test "getblob fails on RO container using non-existing identity" assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB_RO --file download.txt --identity non-existing"
 
+
 testing class "setblob"
 test "setblob fails on NA container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_NA"
 test "setblob fails on RO container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_RO"
 test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
+
+
+# TODO: IGOR TAGGED: PROCEED FROM HERE
 
 DOWNLOADED_BLOB="azmi_itest_downloaded.txt"
 test "Read blob contents from RW container" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOADED_BLOB"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -67,6 +67,7 @@ test "get access token in JWT format" assert.Success "azmi gettoken --jwt-format
 BLOB_NA="restricted_access_blob.txt"
 BLOB_RO="read_only_blob.txt"
 DOWNLOAD_FILE="download.txt"
+DOWNLOAD_DIR="./Download"
 
 testing class "getblob"
 test "getblob fails on NA container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB_NA --file $DOWNLOAD_FILE"
@@ -113,21 +114,17 @@ BC=0; PREFIX="noBlobsShouldDownload"
 test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC
 
 
-# TODO: IGOR TAGGED: PROCEED FROM HERE
-
-# getblobs subcommand
 testing class "getblobs"
-DOWNLOAD_DIR="./Download"; EXPECTED_BLOB_COUNT=5; EXPECTED_SUCCESSES=6 # last one is summary
-rm -rf $DOWNLOAD_DIR
-test "We should successfully download $EXPECTED_BLOB_COUNT blobs from listblobs container" assert.Equals "azmi getblobs --container $CONTAINER_LB --directory $DOWNLOAD_DIR | grep Success | wc -l" $EXPECTED_SUCCESSES
+BC=5; rm -rf $DOWNLOAD_DIR
+test "getblobs downloads $BC blobs" assert.Equals "azmi getblobs --container $CONTAINER_LB --directory $DOWNLOAD_DIR | grep Success | wc -l" $((BC+1))
+# there is one extra line for summary
+BC=3; PREFIX="neu-pre"; rm -rf $DOWNLOAD_DIR
+test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --prefix $PREFIX | grep Success | wc -l" $((BC+1))
+BC=0; PREFIX="noBlobsShouldDownload"; rm -rf $DOWNLOAD_DIR
+test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --prefix $PREFIX | wc -l" $BC
 
-EXPECTED_BLOB_COUNT=3; PREFIX="neu-pre"; EXPECTED_SUCCESSES=4
-rm -rf $DOWNLOAD_DIR
-test "We should successfully download $EXPECTED_BLOB_COUNT blobs with prefix '$PREFIX' from listblobs container" assert.Equals "azmi getblobs --container $CONTAINER_LB --directory $DOWNLOAD_DIR --prefix $PREFIX | grep Success | wc -l" $EXPECTED_SUCCESSES
 
-EXPECTED_BLOB_COUNT=0; PREFIX="noBlobsShouldDownload"; EXPECTED_ROWS=0
-rm -rf $DOWNLOAD_DIR
-test "We should successfully download $EXPECTED_BLOB_COUNT blobs with prefix '$PREFIX' from listblobs container" assert.Equals "azmi getblobs --container $CONTAINER_LB --directory $DOWNLOAD_DIR --prefix $PREFIX | wc -l" $EXPECTED_ROWS
+# TODO: IGOR TAGGED: PROCEED FROM HERE
 
 # testing setblob-byblob 
 testing class "setblob-byblob"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -127,13 +127,10 @@ test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getb
 
 # TODO: IGOR TAGGED: PROCEED FROM HERE
 
-# testing setblob-byblob 
-testing class "setblob-byblob"
-test "Upload tmp file by blob" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --blob ${CONTAINER_RW}/byblob/${UPLOADFILE}"
-
 
 # --if-newer option
 testing class "--if-newer option"
+
 test "Should skip: Download blob and write to file only if difference has been spotted (--if-newer option)" assert.Equals \
   "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/${UPLOADFILE} --if-newer" "Skipped. Blob is not newer than file."
 sleep 1s
@@ -142,7 +139,7 @@ test "Download blob and write to file only if difference has been spotted (--if-
   "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/${UPLOADFILE} --if-newer" "Success"
 TIMESTAMP=$(date "+%Y%m%d_%H%M%S") # e.g. 20200107_144102
 test "Download blob and write to file which does not exist yet (--if-newer option)" assert.Equals \
-  "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/unique-file.${TIMESTAMP} --if-newer" "Success"
+  "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file /tmp/unique-file.${TIMESTAMP} --if-newer --verbose" "Success"
 
 # uninstalling
 testing class "package"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -27,22 +27,25 @@ test "Install fake package should fail" assert.Fail "apt --assume-yes install so
 # dependencies installed?
 test "Check all dependencies are installed" assert.Success "dpkg -s libstdc++6"
 
-install_azmi
 test "Install $PACKAGENAME package from file" assert.Success "dpkg -i $PACKAGEFILE"
 test "Verify azmi binary exists and is executable" assert.Success "[ -x /usr/bin/azmi ]"
 
 testing class "help"
-test "Should fail if no arguments are provided" assert.Fail "azmi"
+test "Fail if no arguments are provided" assert.Fail "azmi"
 test "Print help and return success status" assert.Success "azmi --help"
 
-test "Print help for gettoken" assert.Success "azmi gettoken --help"
-test "Fail gettoken with wrong args" assert.Fail "azmi gettoken blahblah"
+foreach subcommand (gettoken getblob setblob)
+  test "Print help for $subcommand" assert.Success "azmi $subcommand --help"
+  test "Fail $subcommand with wrong args" assert.Fail "azmi $subcommand blahblah"
+end
+# test "Print help for gettoken" assert.Success "azmi gettoken --help"
+# test "Fail gettoken with wrong args" assert.Fail "azmi gettoken blahblah"
 
-test "Print help for getblob" assert.Success "azmi getblob --help"
-test "Fail getblob with wrong args" assert.Fail "azmi getblob blahblah"
+# test "Print help for getblob" assert.Success "azmi getblob --help"
+# test "Fail getblob with wrong args" assert.Fail "azmi getblob blahblah"
 
-test "Print help for setblob" assert.Success "azmi setblob --help"
-test "Fail setblob with wrong args" assert.Fail "azmi setblob blahblah"
+# test "Print help for setblob" assert.Success "azmi setblob --help"
+# test "Fail setblob with wrong args" assert.Fail "azmi setblob blahblah"
 # TODO Automate above using list of supported subcommands
 
 

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -89,7 +89,7 @@ test "setblob overwrites blob on container" assert.Success "azmi setblob -f $UPL
 test "setblob overwrites blob on blob" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 
 testing class "SHA256"
-# it is using file uploaded in previous step
+# it is using the file uploaded in previous step
 test "getblob SHA256 download" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE"
 test "SHA256 same contents" assert.Success "diff $UPLOADFILE $DOWNLOAD_FILE"
 UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
@@ -102,22 +102,19 @@ test "upload tmp file" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --cont
 test "there is no noname folder" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${UPLOADFILE}"
 
 
-# TODO: IGOR TAGGED: PROCEED FROM HERE
-
 testing class "listblobs"
-### list-blobs container
-# Role(s):    Storage Blob Data Contributor
-# Profile(s): bt-seu-test-id (obj. ID: d1c05b65-ccf9-47bd-870d-4e44d209ee7a), kotipoiss-identity (obj. ID: ccb781af-a4eb-4ecc-b183-cef74b3cc717)
-test "List all blobs in listblobs container" assert.Success "azmi listblobs --container $CONTAINER_LB"
-EXPECTED_BLOB_COUNT=5
-test "There should be $EXPECTED_BLOB_COUNT listed blobs in listblobs container" assert.Equals "azmi listblobs --container $CONTAINER_LB | wc -l" $EXPECTED_BLOB_COUNT
-# listing with an optional --prefix
-EXPECTED_BLOB_COUNT=3; PREFIX="neu-pre"
-test "There should be $EXPECTED_BLOB_COUNT listed blobs with prefix '$PREFIX' in listblobs container" assert.Equals "azmi listblobs --container $CONTAINER_LB --prefix $PREFIX | wc -l" $EXPECTED_BLOB_COUNT
-EXPECTED_BLOB_COUNT=1; PREFIX="neu-pre-show-me-only"
-test "There should be $EXPECTED_BLOB_COUNT listed blob with prefix '$PREFIX' in listblobs container" assert.Equals "azmi listblobs --container $CONTAINER_LB --prefix $PREFIX | wc -l" $EXPECTED_BLOB_COUNT
-EXPECTED_BLOB_COUNT=0; PREFIX="noBlobsShouldDownload"
-test "There should be $EXPECTED_BLOB_COUNT listed blob with prefix '$PREFIX' in listblobs container" assert.Equals "azmi listblobs --container $CONTAINER_LB --prefix $PREFIX | wc -l" $EXPECTED_BLOB_COUNT
+BC=5 # blob count
+test "listblobs basic" assert.Success "azmi listblobs --container $CONTAINER_LB"
+test "listblobs finds $BC blobs" assert.Equals "azmi listblobs --container $CONTAINER_LB | wc -l" $BC
+BC=5; PREFIX="neu-pre"
+test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC
+BC=1; PREFIX="neu-pre-show-me-only"
+test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC
+BC=0; PREFIX="noBlobsShouldDownload"
+test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC
+
+
+# TODO: IGOR TAGGED: PROCEED FROM HERE
 
 # getblobs subcommand
 testing class "getblobs"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -19,8 +19,6 @@ PACKAGEFILE=/tmp/azmiX.deb
 declare -a subCommands=("gettoken" "getblob" "getblobs" "setblob" "listblobs")
 identity_foreign=017dc05c-4d12-4ac2-b5f8-5e239dc8bc54
 
-# calculated variables
-
 
 #
 # start testing

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -3,28 +3,23 @@
 # AzMiTool Integration tests
 # It requires Bash Testing Framework
 
+
+#
 # setup variables
+#
+
 export DEBIAN_FRONTEND=noninteractive
 PACKAGENAME=azmi
 PACKAGEFILE=/tmp/azmiX.deb
+STORAGEACCOUNTNAME=azmitest
 
-# define function(s)
-function install_azmi() { # installs/upgrades package from file if exists; otherwise APT repository
-  if $(dpkg-query --show $PACKAGENAME > /dev/null 2>&1); then
-    EVENT="Upgrade"
-  else
-    EVENT="Install"
-  fi
+# calculated variables
+CONTAINER_NA="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-no-access"
 
-  if [ -f $PACKAGEFILE ]; then
-      test "$EVENT $PACKAGENAME package from file" assert.Success "dpkg -i $PACKAGEFILE"
-  else
-      test "$EVENT $PACKAGENAME package from repository" assert.Success "apt --assume-yes install $PACKAGENAME"
-  fi  
-  dpkg-query --showformat='  - ${Package} ${Version} installed\n' --show $PACKAGENAME
-}
-
+#
 # start testing
+#
+
 testing start "$PACKAGENAME"
 testing class "package"
 test "Install fake package should fail" assert.Fail "apt --assume-yes install somenonexistingpackage"
@@ -33,8 +28,8 @@ test "Install fake package should fail" assert.Fail "apt --assume-yes install so
 test "Check all dependencies are installed" assert.Success "dpkg -s libstdc++6"
 
 install_azmi
+test "Install $PACKAGENAME package from file" assert.Success "dpkg -i $PACKAGEFILE"
 test "Verify azmi binary exists and is executable" assert.Success "[ -x /usr/bin/azmi ]"
-
 
 testing class "help"
 test "Should fail if no arguments are provided" assert.Fail "azmi"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -11,6 +11,8 @@
 # TODO: remove these two from script, or change it to $1, $2
 STORAGEACCOUNTNAME=azmitest
 identity=354800af-354e-42e0-906b-5b96e02c4e1c
+echo "First argument: '$1'"
+
 
 export DEBIAN_FRONTEND=noninteractive
 PACKAGENAME=azmi

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -108,7 +108,7 @@ test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getb
 BC=0; PREFIX="noBlobsShouldDownload"; rm -rf $DOWNLOAD_DIR
 test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --prefix $PREFIX | wc -l" $BC
 BC=4; EXCLUDE="neu-pre-logboxA1"; rm -rf $DOWNLOAD_DIR
-test "getblobs downloads $BC blobs excluding $EXCLUDE" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --exclude $EXCLUDE | grep Success | wc -l" $BC
+test "getblobs downloads $BC blobs excluding $EXCLUDE" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --exclude $EXCLUDE | grep Success | wc -l" $((BC+1))
 
 
 testing class "setblob"

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -16,6 +16,7 @@ declare -a subCommands=("gettoken" "getblob" "getblobs" "setblob" "listblobs")
 
 # calculated variables
 CONTAINER_NA="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-no-access"
+CONTAINER_RO="https://${STORAGEACCOUNTNAME}.blob.core.windows.net/azmi-itest-r"
 
 #
 # start testing
@@ -68,25 +69,30 @@ test "Authenticate to Azure using a managed identity and get access token in JWT
 # https://azmitest.blob.core.windows.net/azmi-itest-rw//tmp/azmi_itest_20200206_091521.txt
 #         storage account URL           |containerName|          blob name
 
+
+
+#
+# storage subcommands testing
+#
+
+
 ### no-access container ###
-CONTAINER_URL="https://azmitest.blob.core.windows.net/azmi-itest-no-access"
 BLOB="restricted_access_blob.txt"
-test "Should fail: Read blob contents from restricted Azure storage container" assert.Fail "azmi getblob --blob $CONTAINER_URL/$BLOB --file download.txt"
+test "Should fail: Read blob contents from restricted Azure storage container" assert.Fail "azmi getblob --blob $CONTAINER_NA/$BLOB --file download.txt"
 date > upload.txt # generate unique file contents
-test "Should fail: Save file contents to restricted Azure storage container" assert.Fail "azmi setblob --file upload.txt --container $CONTAINER_URL"
+test "Should fail: Save file contents to restricted Azure storage container" assert.Fail "azmi setblob --file upload.txt --container $CONTAINER_NA"
 rm upload.txt
 
 ### read-only container ###
 # Role(s):    Storage Blob Data Reader
 # Profile(s): bt-seu-test-id (obj. ID: d1c05b65-ccf9-47bd-870d-4e44d209ee7a), kotipoiss-identity (obj. ID: ccb781af-a4eb-4ecc-b183-cef74b3cc717)
-CONTAINER_URL="https://azmitest.blob.core.windows.net/azmi-itest-r"
 BLOB="read_only_blob.txt"
-test "Read blob contents from read-only Azure storage container" assert.Success "azmi getblob --blob $CONTAINER_URL/$BLOB --file download.txt"
-test "Should fail: Save file contents to read-only Azure storage container" assert.Fail "azmi setblob --file download.txt --container $CONTAINER_URL"
+test "Read blob contents from read-only Azure storage container" assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt"
+test "Should fail: Save file contents to read-only Azure storage container" assert.Fail "azmi setblob --file download.txt --container $CONTAINER_RO"
 # test --identity options
-test "Read blob contents from read-only Azure storage container using right identity"                     assert.Success "azmi getblob --blob $CONTAINER_URL/$BLOB --file download.txt --identity 354800af-354e-42e0-906b-5b96e02c4e1c"
-test "Should fail: Read blob contents from read-only Azure storage container using foreign identity"      assert.Fail    "azmi getblob --blob $CONTAINER_URL/$BLOB --file download.txt --identity 017dc05c-4d12-4ac2-b5f8-5e239dc8bc54"
-test "Should fail: Read blob contents from read-only Azure storage container using non-existing identity" assert.Fail    "azmi getblob --blob $CONTAINER_URL/$BLOB --file download.txt --identity non-existing"
+test "Read blob contents from read-only Azure storage container using right identity"                     assert.Success "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt --identity 354800af-354e-42e0-906b-5b96e02c4e1c"
+test "Should fail: Read blob contents from read-only Azure storage container using foreign identity"      assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt --identity 017dc05c-4d12-4ac2-b5f8-5e239dc8bc54"
+test "Should fail: Read blob contents from read-only Azure storage container using non-existing identity" assert.Fail    "azmi getblob --blob $CONTAINER_RO/$BLOB --file download.txt --identity non-existing"
 
 ### read-write container ###
 # Role(s):    Storage Blob Data Contributor

--- a/test/integration/integration_test.sh
+++ b/test/integration/integration_test.sh
@@ -12,6 +12,8 @@
 STORAGEACCOUNTNAME=azmitest
 identity=354800af-354e-42e0-906b-5b96e02c4e1c
 echo "First argument: '$1'"
+echo "Second argument: '$2'"
+echo "Third argument: '$3'"
 
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Main points from this PR:
- moved `storage account` and `identity` to script arguments (pipeline updated)
- tests grouped per command
- reused variables separated to multiple 

Future tasks that will be done in additional issues:
- #97 - split integration tests into multiple files (once we start with key vault things)
- #99 - testing documentation web page and generalize names/pipeline

Resolves #47 

Build ID [28579956](https://skype.visualstudio.com/SCC/_build/results?buildId=28579956&view=ms.vss-test-web.build-test-results-tab) with commit 96af026 (resolved conflict) completed successfully. 