### PR TITLE
Exceptions2

### DIFF
--- a/src/azmi-main/AzmiException.cs
+++ b/src/azmi-main/AzmiException.cs
@@ -5,9 +5,7 @@ namespace azmi_main
     [Serializable]
     public class AzmiException : Exception
     {
-        public AzmiException()
-        {
-        }
+        public AzmiException() { }
 
         public AzmiException(string message) : base(message) { }
 
@@ -18,17 +16,15 @@ namespace azmi_main
 
         internal static Exception IDCheck(string identity, Exception ex)
         {
-            if (string.IsNullOrEmpty(identity) && TryGetTokenFails())
+            if (string.IsNullOrEmpty(identity) && GetTokenFails())
             {
                 return new AzmiException("Missing identity argument", ex);
-            }
-            else if (ex.Message.Contains("See inner exception for details.") && (ex.InnerException != null))
+            } else if (ex.Message.Contains("See inner exception for details.") && (ex.InnerException != null))
             {
                 if (ex.InnerException.Message.Contains("Identity not found"))
                 {
                     return new AzmiException("Managed identity not found", ex);
-                }
-                else
+                } else
                 {
                     return ex.InnerException;
                 }
@@ -43,11 +39,11 @@ namespace azmi_main
             return new AzmiException("Cannot convert input object to proper class", ex);
         }
 
-        private static bool TryGetTokenFails()
+        private static bool GetTokenFails()
         {
             try
             {
-                (new GetToken()).Execute("");
+                (new GetToken()).Execute(identity: null);
                 return false;
             } catch
             {

--- a/src/azmi-main/AzmiException.cs
+++ b/src/azmi-main/AzmiException.cs
@@ -2,18 +2,36 @@
 
 namespace azmi_main
 {
-    internal static class AzmiException
+    [Serializable]
+    public class AzmiException : Exception
     {
+        public AzmiException()
+        {
+        }
+
+        public AzmiException(string message) : base(message) { }
+
+        public AzmiException(string message, Exception ex) : base(message, ex) { }
+
+        protected AzmiException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext) { }
+
         internal static Exception IDCheck(string identity, Exception ex)
         {
-            if (string.IsNullOrEmpty(identity))
+            if (string.IsNullOrEmpty(identity) && TryGetTokenFails())
             {
-                return new ArgumentNullException("Missing identity argument", ex);
-            } else if (ex.Message.Contains("See inner exception for details.")
-                && (ex.InnerException != null)
-                && (ex.InnerException.Message.Contains("Identity not found")))
+                return new AzmiException("Missing identity argument", ex);
+            }
+            else if (ex.Message.Contains("See inner exception for details.") && (ex.InnerException != null))
             {
-                return new ArgumentException("Managed identity not found", ex);
+                if (ex.InnerException.Message.Contains("Identity not found"))
+                {
+                    return new AzmiException("Managed identity not found", ex);
+                }
+                else
+                {
+                    return ex.InnerException;
+                }
             } else
             {
                 return ex;
@@ -22,7 +40,19 @@ namespace azmi_main
 
         internal static Exception WrongObject(Exception ex)
         {
-            return new ArgumentException("Cannot convert input object to proper class", ex);
+            return new AzmiException("Cannot convert input object to proper class", ex);
+        }
+
+        private static bool TryGetTokenFails()
+        {
+            try
+            {
+                (new GetToken()).Execute("");
+                return false;
+            } catch
+            {
+                return true;
+            }
         }
     }
 }

--- a/src/azmi-main/blob/SetBlob.cs
+++ b/src/azmi-main/blob/SetBlob.cs
@@ -52,12 +52,10 @@ namespace azmi_main
 
             if (String.IsNullOrEmpty(opt.blob) && String.IsNullOrEmpty(opt.container))
             {
-                // TODO: Setup AzmiExceptions
-                throw new ArgumentException("You must specify either blob or container url");
+                throw new AzmiException("You must specify either blob or container url");
             } else if ((!String.IsNullOrEmpty(opt.blob)) && (!String.IsNullOrEmpty(opt.container)))
             {
-                // TODO: Setup AzmiExceptions
-                throw new ArgumentException("Cannot use both container and blob url");
+                throw new AzmiException("Cannot use both container and blob url");
             }
 
             if (String.IsNullOrEmpty(opt.blob))


### PR DESCRIPTION
Following new functionalities implemented - no impact on end results
- class `AzmiException` implements `Exception`
- it throws `Missing Identity` only if `gettoken` with no identity fails

Benefits will be visible only if we publish `azmi-main` as nuget

resolves #64 

[integration test](https://skype.visualstudio.com/SCC/_build/results?buildId=29162594) completed with no failures