### PR TITLE
simplify setblob command

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -58,7 +58,7 @@ Print token in JSON Web Token (JWT) format.
 |**`listblobs`**|`--container`| *n.a.* |`--prefix`, `--exclude`|
 |**`getblob`**|`--blob`|`--file`|`--if-newer`, `--delete-after-copy`|
 |**`getblobs`**|`--container`|`--directory`|`--prefix`, `--if-newer`, `--delete-after-copy`, `--exclude`|
-|**`setblob`**|`--file`|`--blob` or `--container`|`--force`|
+|**`setblob`**|`--file`|`--blob` |`--force`|
 
 All commands support arguments `--identity` and `--verbose`.
 

--- a/Examples.md
+++ b/Examples.md
@@ -50,14 +50,11 @@ azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --prefix $PREFIX
 azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --exclude $EXCLUDE
 
 
-# upload file to storage account container
-azmi setblob -f $UPLOADFILE --container $CONTAINER
-
 # upload file and specify exact uploaded blob URL
 azmi setblob -f $UPLOADFILE --blob $BLOBURL
 
 # upload file even if exact blob already exists
-azmi setblob -f $UPLOADFILE --container $CONTAINER --force
+azmi setblob -f $UPLOADFILE --blob $BLOBURL --force
 ```
 
 ### Comments

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ azmi getblob --blob $BLOB_URL --file $FILE
 # download blobs from a storage account container and save them to folder
 azmi getblobs --container $CONTAINER_URL --directory ./downloadBlobsHere  
 
-# upload file as a blob to storage account container
-azmi setblob --file $FILE --container $CONTAINER_URL
-
 # upload file by specifying blob url and identity
 azmi setblob --file ~/info.txt --blob $CONTAINER_URL/myhostname/info.txt --identity 117dc05c-4d12-4ac2-b5f8-5e239dc8bc54
 

--- a/src/azmi-main/blob/SetBlob.cs
+++ b/src/azmi-main/blob/SetBlob.cs
@@ -19,9 +19,7 @@ namespace azmi_main
                 arguments = new AzmiArgument[] {
                     new AzmiArgument("file", required: true,
                         description: "Path to local file which will be uploaded. Examples: /tmp/1.txt, ./1.xml"),
-                    new AzmiArgument("container", required: false, type: ArgType.url,
-                        description: "URL of container to which file will be uploaded. Cannot be used together with --blob. Example: https://myaccount.blob.core.windows.net/mycontainer"),
-                    new AzmiArgument("blob", required: false, type: ArgType.url,
+                    new AzmiArgument("blob", required: true, type: ArgType.url,
                         description: "URL of blob to which file will be uploaded. Cannot be used together with --container. Example: https://myaccount.blob.core.windows.net/mycontainer/myblob.txt"),
                     new AzmiArgument("force", alias: null, type: ArgType.flag,
                         description: "Overwrite existing blob in Azure."),
@@ -50,57 +48,15 @@ namespace azmi_main
                 throw AzmiException.WrongObject(ex);
             }
 
-            if (String.IsNullOrEmpty(opt.blob) && String.IsNullOrEmpty(opt.container))
-            {
-                throw new AzmiException("You must specify either blob or container url");
-            } else if ((!String.IsNullOrEmpty(opt.blob)) && (!String.IsNullOrEmpty(opt.container)))
-            {
-                throw new AzmiException("Cannot use both container and blob url");
-            }
-
-            if (String.IsNullOrEmpty(opt.blob))
-            {
-                return SetBlob.setBlob_byContainer(opt.file, opt.container, opt.identity, opt.force).ToStringList();
-            } else
-            {
-                return SetBlob.setBlob_byBlob(opt.file, opt.blob, opt.identity, opt.force).ToStringList();
-            }
+            return Execute(opt.file, opt.blob, opt.identity, opt.force).ToStringList();
         }
 
         //
         // Execute SetBlob
         //
 
-        public static string setBlob_byContainer(string filePath, string containerUri, string identity = null, bool force = false)
+        public static string Execute(string filePath, string blobUri, string identity = null, bool force = false)
         {
-            if (!(File.Exists(filePath)))
-            {
-                throw new FileNotFoundException($"File '{filePath}' not found!");
-            }
-
-            var Cred = new ManagedIdentityCredential(identity);
-            var containerClient = new BlobContainerClient(new Uri(containerUri), Cred);
-            containerClient.CreateIfNotExists();
-            var blobClient = containerClient.GetBlobClient(filePath.TrimStart('/'));
-            try
-            {
-                blobClient.Upload(filePath, force);
-                return "Success";
-            } catch (Exception ex)
-            {
-                throw AzmiException.IDCheck(identity, ex);
-            }
-        }
-
-        // Sets blob content based on local file content into blob
-        public static string setBlob_byBlob(string filePath, string blobUri, string identity = null, bool force = false)
-        {
-            // sets blob content based on local file content with provided blob url
-            if (!(File.Exists(filePath)))
-            {
-                throw new FileNotFoundException($"File '{filePath}' not found!");
-            }
-
             var Cred = new ManagedIdentityCredential(identity);
             var blobClient = new BlobClient(new Uri(blobUri), Cred);
             try
@@ -112,7 +68,5 @@ namespace azmi_main
                 throw AzmiException.IDCheck(identity, ex);
             }
         }
-
-
     }
 }

--- a/src/azmi-main/blob/SetBlob.cs
+++ b/src/azmi-main/blob/SetBlob.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Azure.Identity;
 using Azure.Storage.Blobs;
-using System.IO;
 
 namespace azmi_main
 {

--- a/test/integration/blob-tests.sh
+++ b/test/integration/blob-tests.sh
@@ -90,24 +90,25 @@ UPLOADFILE_SHA256=$(sha256sum "$UPLOADFILE" | awk '{ print $1 }')
 DOWNLOADFILE_SHA256=$(sha256sum $DOWNLOAD_FILE | awk '{ print $1 }')
 test "SHA256 same checksums" assert.Success "[ $UPLOADFILE_SHA256 = $DOWNLOADFILE_SHA256 ]"
 
-testing class "noname"
-test "prepare tmp file" assert.Success "rm -f /tmp/${UPLOADFILE} && echo sometext > /tmp/${UPLOADFILE}"
-test "upload tmp file" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
-test "there is no noname folder" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${UPLOADFILE}"
+# noname tests make no sense without --container argument
+#testing class "noname"
+#test "prepare tmp file" assert.Success "rm -f /tmp/${UPLOADFILE} && echo sometext > /tmp/${UPLOADFILE}"
+#test "upload tmp file" assert.Success "azmi setblob -f /tmp/${UPLOADFILE} --container ${CONTAINER_RW}"
+#test "there is no noname folder" assert.Fail "azmi getblob -f /dev/null -b ${CONTAINER_RW}//tmp/${UPLOADFILE}"
 
 testing class "if-newer"
 SKIPMSG="Skipped. Blob is not newer than file."
-test "setblob if-newer upload" assert.Equals "azmi setblob -f $UPLOADFILE -c $CONTAINER_RW"
+test "setblob if-newer upload" assert.Equals "azmi setblob -f $UPLOADFILE -b ${CONTAINER_RW}/${UPLOADFILE}"
 touch "$UPLOADFILE"
 test "getblob skips if not newer" assert.Equals "azmi getblob -b ${CONTAINER_RW}/${UPLOADFILE} -f $UPLOADFILE --if-newer" "$SKIPMSG"
-test "setblob updates blob" assert.Success "azmi setblob -f $UPLOADFILE -c $CONTAINER_RW --force"
+test "setblob updates blob" assert.Success "azmi setblob -f $UPLOADFILE -b ${CONTAINER_RW}/${UPLOADFILE} --force"
 sleep 1
 test "getblob downloads if newer" assert.Equals "azmi getblob -b ${CONTAINER_RW}/${UPLOADFILE} -f $UPLOADFILE --if-newer" "Success"
 rm -rf $DOWNLOAD_FILE
 test "getblob downloads newer than nonexisting" assert.Equals "azmi getblob -b ${CONTAINER_RW}/${UPLOADFILE} -f $DOWNLOAD_FILE --if-newer" "Success"
 
 testing class "delete-after-copy"
-test "setblob delete-after-copy upload" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW --force"
+test "setblob delete-after-copy upload" assert.Success "azmi setblob --file $UPLOADFILE -b ${CONTAINER_RW}/${UPLOADFILE} --force"
 test "getblob remove blob with delete-after-copy" assert.Success "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE --delete-after-copy"
 test "getblob fails with deleted file" assert.Fail "azmi getblob --blob ${CONTAINER_RW}/${UPLOADFILE} --file $DOWNLOAD_FILE"
 

--- a/test/integration/blob-tests.sh
+++ b/test/integration/blob-tests.sh
@@ -71,15 +71,13 @@ test "getblobs downloads $BC blobs excluding $EXCLUDE" assert.Equals "azmi getbl
 
 
 testing class "setblob"
-test "setblob fails on NA container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_NA"
-test "setblob fails on RO container" assert.Fail "azmi setblob --file $UPLOADFILE --container $CONTAINER_RO"
-test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFILE --container $CONTAINER_RW"
+test "setblob fails on NA container" assert.Fail "azmi setblob --file $UPLOADFILE --blob ${CONTAINER_NA}/${UPLOADFILE}"
+test "setblob fails on RO container" assert.Fail "azmi setblob --file $UPLOADFILE --blob ${CONTAINER_RO}/${UPLOADFILE}"
+test "setblob OK on RW container" assert.Success "azmi setblob --file $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE}"
 
 testing class "setblob force"
-test "setblob fails to overwrite on container" assert.Fail "azmi setblob -f $UPLOADFILE --container $CONTAINER_RW"
-test "setblob fails to overwrite on blob" assert.Fail "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE}"
-test "setblob overwrites blob on container" assert.Success "azmi setblob -f $UPLOADFILE --container $CONTAINER_RW --force"
-test "setblob overwrites blob on blob" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force --verbose"
+test "setblob fails to overwrite blob" assert.Fail "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE}"
+test "setblob overwrites blob with force" assert.Success "azmi setblob -f $UPLOADFILE --blob ${CONTAINER_RW}/${UPLOADFILE} --force"
 
 # TODO: Add here setblobs tests
 


### PR DESCRIPTION
Removing `--container` argument from `setblob` command. This aligns `setblob` with other commands and simplifies its code.

Documentation and tests updated.

Resolves #105 

Also, these modifications render `no noname folder` tests obsolete.
[Integration test](https://dev.azure.com/iiric/azmi/_build/results?buildId=1561&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=275f1d19-1bd8-5591-b06b-07d489ea915a) was successful. 