### PR TITLE
Multi valued

### DIFF
--- a/src/azmi-commandline/AzmiCommandLineExtensions.cs
+++ b/src/azmi-commandline/AzmiCommandLineExtensions.cs
@@ -96,7 +96,6 @@ namespace azmi_commandline
                     } catch (Exception ex) {
                         DisplayError(cmd.Definition().name, ex, op.verbose);
                     } });
-
             return commandLineSubCommand;
         }
 

--- a/src/azmi-commandline/AzmiCommandLineExtensions.cs
+++ b/src/azmi-commandline/AzmiCommandLineExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("azmi-main-tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("azmi-commandline-tests")]
@@ -48,12 +49,18 @@ namespace azmi_commandline
 
         internal static Option ToOption(this AzmiArgument option)
         {
-            return new Option(option.OptionNames())
+            var opt = new Option(option.OptionNames())
             {
                 Argument = option.OptionArgument(),
                 Description = option.OptionDescription(),
                 Required = option.required
             };
+            if (option.multiValued)
+            {
+                opt.Argument.Arity = ArgumentArity.OneOrMore;
+                // TODO: Should optional arguments have ZeroOrMore?
+            }
+            return opt;
         }
 
         internal static Command ToCommand<T, TOptions>()

--- a/src/azmi-commandline/AzmiCommandLineExtensions.cs
+++ b/src/azmi-commandline/AzmiCommandLineExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Runtime.CompilerServices;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("azmi-main-tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("azmi-commandline-tests")]
@@ -27,27 +26,14 @@ namespace azmi_commandline
 
         internal static Argument OptionArgument(this AzmiArgument option)
         {
-            if (option.multiValued)
+            switch (option.type)
             {
-                switch (option.type)
-                {
-                    case ArgType.str: return new Argument<string[]>("string");
-                    case ArgType.flag: return new Argument<bool>("bool");
-                    case ArgType.url: return new Argument<string[]>("url");
-
-                    default: throw new ArgumentException($"Unsupported option type: {option.type}");
-                }
-
-            } else
-            {
-                switch (option.type)
-                {
-                    case ArgType.str: return new Argument<string>("string");
-                    case ArgType.flag: return new Argument<bool>("bool");
-                    case ArgType.url: return new Argument<string>("url");
-
-                    default: throw new ArgumentException($"Unsupported option type: {option.type}");
-                }
+                case ArgType.flag: return new Argument<bool>("bool");
+                case ArgType.str when (option.multiValued): return new Argument<string[]>("string");
+                case ArgType.url when (option.multiValued): return new Argument<string[]>("url");
+                case ArgType.str when (!option.multiValued): return new Argument<string>("string");
+                case ArgType.url when (!option.multiValued): return new Argument<string>("url");
+                default: throw new ArgumentException($"Unsupported option type: {option.type}");
             }
         }
 
@@ -96,6 +82,7 @@ namespace azmi_commandline
                     } catch (Exception ex) {
                         DisplayError(cmd.Definition().name, ex, op.verbose);
                     } });
+
             return commandLineSubCommand;
         }
 

--- a/src/azmi-commandline/AzmiCommandLineExtensions.cs
+++ b/src/azmi-commandline/AzmiCommandLineExtensions.cs
@@ -27,13 +27,27 @@ namespace azmi_commandline
 
         internal static Argument OptionArgument(this AzmiArgument option)
         {
-            switch (option.type)
+            if (option.multiValued)
             {
-                case ArgType.str: return new Argument<string>("string");
-                case ArgType.flag: return new Argument<bool>("bool");
-                case ArgType.url: return new Argument<string>("url");
+                switch (option.type)
+                {
+                    case ArgType.str: return new Argument<string[]>("string");
+                    case ArgType.flag: return new Argument<bool>("bool");
+                    case ArgType.url: return new Argument<string[]>("url");
 
-                default: throw new ArgumentException($"Unsupported option type: {option.type}");
+                    default: throw new ArgumentException($"Unsupported option type: {option.type}");
+                }
+
+            } else
+            {
+                switch (option.type)
+                {
+                    case ArgType.str: return new Argument<string>("string");
+                    case ArgType.flag: return new Argument<bool>("bool");
+                    case ArgType.url: return new Argument<string>("url");
+
+                    default: throw new ArgumentException($"Unsupported option type: {option.type}");
+                }
             }
         }
 

--- a/src/azmi-commandline/azmi-commandline.csproj
+++ b/src/azmi-commandline/azmi-commandline.csproj
@@ -19,7 +19,7 @@ It is utilizing Azure AD authentication via user assigned managed identity.</Des
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19577.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/azmi-main/AzmiArgument.cs
+++ b/src/azmi-main/AzmiArgument.cs
@@ -20,47 +20,53 @@ namespace azmi_main
         public string description { get; set; }
         public bool required { get; set; }
         public ArgType type { get; set; } // string, url or bool
+        public bool multiValued { get; set; }
 
         private const ArgType defaultType = ArgType.str;
         private const bool defaultRequired = false;
+        private const bool defaultMultiValued = false;
 
-        internal AzmiArgument(string name, char? alias, string description, bool required, ArgType type)
+        internal AzmiArgument(string name, char? alias, string description, bool required, ArgType type, bool multiValued)
         {
             this.name = name;
             this.alias = alias;
             this.description = description;
             this.required = required;
             this.type = type;
+            this.multiValued = multiValued;
         }
 
         // constructor NAME with one string
         internal AzmiArgument(string name,
-            ArgType type = defaultType, bool required = defaultRequired)
+            ArgType type = defaultType, bool required = defaultRequired, bool multiValued = defaultMultiValued)
         : this(
             name,
             name[0],
             $"Description for {name}",
             required,
-            type) { }
+            type,
+            multiValued) { }
 
         // constructor NAME + ALIAS? + DESCRIPTION
         internal AzmiArgument(string name, char? alias, string description,
-            ArgType type = defaultType, bool required = defaultRequired)
+            ArgType type = defaultType, bool required = defaultRequired, bool multiValued = defaultMultiValued)
         : this(
             name,
             alias,
             description,
             required,
-            type) { }
+            type,
+            multiValued) { }
 
         // constructor NAME + DESCRIPTION
         internal AzmiArgument(string name, [DisallowNull]string description,
-            ArgType type = defaultType, bool required = defaultRequired)
+            ArgType type = defaultType, bool required = defaultRequired, bool multiValued = defaultMultiValued)
         : this(
             name,
             name[0],
             description,
             required,
-            type) { }
+            type,
+            multiValued) { }
     }
 }

--- a/src/azmi-main/blob/GetBlobs.cs
+++ b/src/azmi-main/blob/GetBlobs.cs
@@ -67,7 +67,7 @@ namespace azmi_main
         {
             const char blobPathDelimiter = '/';
             string containerUriTrimmed = containerUri.TrimEnd(blobPathDelimiter);
-            List<string> blobsListing = new ListBlobs().Execute(containerUriTrimmed, identity, prefix, exclude );
+            List<string> blobsListing = new ListBlobs().Execute(containerUriTrimmed, identity, prefix, exclude);
             List<string> results = new List<string>();
 
             foreach (var blob in blobsListing)

--- a/src/azmi-main/blob/GetBlobs.cs
+++ b/src/azmi-main/blob/GetBlobs.cs
@@ -6,7 +6,6 @@ namespace azmi_main
 {
     public class GetBlobs : IAzmiCommand
     {
-        private const char blobPathDelimiter = '/';
 
         public SubCommandDefinition Definition()
         {
@@ -22,7 +21,8 @@ namespace azmi_main
                     new AzmiArgument("directory","Path to a local directory to which blobs will be downloaded to. Examples: /home/avalanche/tmp/ or ./",
                         required: true),
                     new AzmiArgument("prefix", "Specifies a string that filters the results to return only blobs whose name begins with the specified prefix"),
-                    new AzmiArgument("exclude", "Exclude blobs that match given regular expression."),
+                    new AzmiArgument("exclude", multiValued: true,
+                        description: "Exclude blobs that match given regular expression."),
                     new AzmiArgument("if-newer", null, "Download blobs only if newer versions exist in a container.",
                         ArgType.flag),
                     new AzmiArgument("delete-after-copy", null, "Successfully downloaded blobs are removed from a container.",
@@ -38,7 +38,7 @@ namespace azmi_main
             public string container { get; set; }
             public string directory { get; set; }
             public string prefix { get; set; }
-            public string exclude { get; set; }
+            public string[] exclude { get; set; }
             public bool ifNewer { get; set; }
             public bool deleteAfterCopy { get; set; }
         }
@@ -63,11 +63,11 @@ namespace azmi_main
         // GetBlobs main method
         //
 
-        public List<string> Execute(string containerUri, string directory, string identity = null, string prefix = null, string exclude = null, bool ifNewer = false, bool deleteAfterCopy = false)
+        public List<string> Execute(string containerUri, string directory, string identity = null, string prefix = null, string[] exclude = null, bool ifNewer = false, bool deleteAfterCopy = false)
         {
-            char blobPathDelimiter = '/';
+            const char blobPathDelimiter = '/';
             string containerUriTrimmed = containerUri.TrimEnd(blobPathDelimiter);
-            List<string> blobsListing = new ListBlobs().Execute(containerUriTrimmed, identity, prefix, exclude);
+            List<string> blobsListing = new ListBlobs().Execute(containerUriTrimmed, identity, prefix, exclude );
             List<string> results = new List<string>();
 
             foreach (var blob in blobsListing)

--- a/src/azmi-main/blob/ListBlobs.cs
+++ b/src/azmi-main/blob/ListBlobs.cs
@@ -23,7 +23,7 @@ namespace azmi_main
                         description: "URL of container for which to list blobs. Example: https://myaccount.blob.core.windows.net/mycontainer"),
                     new AzmiArgument("prefix",
                         description: "Specifies a string that filters the results to return only blobs whose name begins with the specified prefix"),
-                    new AzmiArgument("exclude",
+                    new AzmiArgument("exclude", multiValued: true,
                         description: "Exclude blobs that match given regular expression."),
                     SharedAzmiArguments.identity,
                     SharedAzmiArguments.verbose

--- a/src/azmi-main/blob/ListBlobs.cs
+++ b/src/azmi-main/blob/ListBlobs.cs
@@ -35,7 +35,7 @@ namespace azmi_main
         {
             public string container { get; set; }
             public string prefix { get; set; }
-            public string exclude { get; set; }
+            public string[] exclude { get; set; }
         }
 
         public List<string> Execute(object options)
@@ -57,7 +57,7 @@ namespace azmi_main
         //
 
 
-        public List<string> Execute(string containerUri, string identity = null, string prefix = null, string exclude = null)
+        public List<string> Execute(string containerUri, string identity = null, string prefix = null, string[] exclude = null)
         {
 
             var Cred = new ManagedIdentityCredential(identity);
@@ -70,7 +70,7 @@ namespace azmi_main
 
                 if (exclude != null)
                 { // apply --exclude regular expression
-                    var rx = new Regex(exclude);
+                    var rx = new Regex(String.Join('|',exclude));
                     blobListing = blobListing.Where(b => !rx.IsMatch(b)).ToList();
                 }
                 return blobListing.Count == 0 ? null : blobListing;

--- a/test/azmi-commandline-tests/Extensions-Tests.cs
+++ b/test/azmi-commandline-tests/Extensions-Tests.cs
@@ -173,6 +173,54 @@ namespace azmi_commandline_tests
             }
 
             // TODO: Add more tests for command.handler
+
+            private class DummyAzmiCommand2 : IAzmiCommand
+            {
+                public SubCommandDefinition Definition()
+                {
+                    return new SubCommandDefinition
+                    {
+                        name = "dummy_command",
+                        arguments = new AzmiArgument[] {
+                            SharedAzmiArguments.identity,
+                            new AzmiArgument("exclude", multiValued: true),
+                        }
+                    };
+                }
+
+                public List<string> Execute(object options)
+                {
+                    return new List<string> { "dummy command executed" };
+                }
+            }
+
+            [Fact]
+            public void ToCommand_ProperType2()
+            {
+                var a = AzmiCommandLineExtensions.ToCommand<DummyAzmiCommand2, SharedAzmiArgumentsClass>();
+                Assert.IsType<Command>(a);
+            }
+
+            [Fact]
+            public void ToCommand_ProperOptionCount2()
+            {
+                var a = AzmiCommandLineExtensions.ToCommand<DummyAzmiCommand2, SharedAzmiArgumentsClass>();
+                var actualCount = a.Options.Count();
+                Assert.Equal(2, actualCount);
+            }
+
+            [Fact]
+            public void ToCommand_ProperMultiValuedOption()
+            {
+                var subCommand = AzmiCommandLineExtensions.ToCommand<DummyAzmiCommand2, SharedAzmiArgumentsClass>();
+                var option = subCommand.Options.First(a => a.Name == "exclude");
+                var actualArity = option.Argument.Arity;
+                Assert.Equal(ArgumentArity.OneOrMore.MinimumNumberOfValues, actualArity.MinimumNumberOfValues);
+                Assert.Equal(ArgumentArity.OneOrMore.MaximumNumberOfValues, actualArity.MaximumNumberOfValues);
+                // TODO: use one Assert above, simple Equal is not working for objects
+            }
+
+
         }
 
         public class DisplayError_TestsGroup

--- a/test/azmi-main-tests/AzmiArgument-Tests.cs
+++ b/test/azmi-main-tests/AzmiArgument-Tests.cs
@@ -55,7 +55,9 @@ namespace azmi_tests
             public void SimplestConstructor_DefinesSingleValued()
             {
                 var a = new AzmiArgument("some-name");
-                Assert.False(a.multiValued);
+                var isMultiValued = a.multiValued;
+                Assert.False(isMultiValued);
+
             }
         }
 
@@ -117,14 +119,16 @@ namespace azmi_tests
             public void TwoStringsConstructor_OptionalMultiValuedIsTrue()
             {
                 var a = new AzmiArgument("some-name", "some-description", multiValued: true);
-                Assert.True(a.multiValued);
+                var isMultiValued = a.multiValued;
+                Assert.True(isMultiValued);
             }
 
             [Fact]
             public void TwoStringsConstructor_OptionalMultiValuedIsFalse()
             {
                 var a = new AzmiArgument("some-name", "some-description");
-                Assert.False(a.multiValued);
+                var isMultiValued = a.multiValued;
+                Assert.False(isMultiValued);
             }
         }
 

--- a/test/azmi-main-tests/AzmiArgument-Tests.cs
+++ b/test/azmi-main-tests/AzmiArgument-Tests.cs
@@ -164,6 +164,14 @@ namespace azmi_tests
                 var a = new AzmiArgument("some-name", 'u', "some-description");
                 Assert.False(a.required);
             }
+
+            [Fact]
+            public void ThreeArgsConstructor_AcceptsMultiValued()
+            {
+                var a = new AzmiArgument("some-name", 'u', "some-description", multiValued: true);
+                var isMultiValued = a.multiValued;
+                Assert.True(isMultiValued);
+            }
         }
     }
 }

--- a/test/azmi-main-tests/AzmiArgument-Tests.cs
+++ b/test/azmi-main-tests/AzmiArgument-Tests.cs
@@ -50,6 +50,13 @@ namespace azmi_tests
                 var a = new AzmiArgument("some-name");
                 Assert.False(a.required);
             }
+
+            [Fact]
+            public void SimplestConstructor_DefinesSingleValued()
+            {
+                var a = new AzmiArgument("some-name");
+                Assert.False(a.multiValued);
+            }
         }
 
         public class TwoStringsConstructor_TestsGroup
@@ -104,6 +111,20 @@ namespace azmi_tests
             {
                 var a = new AzmiArgument("some-name", "some-description", required: true);
                 Assert.True(a.required);
+            }
+
+            [Fact]
+            public void TwoStringsConstructor_OptionalMultiValuedIsTrue()
+            {
+                var a = new AzmiArgument("some-name", "some-description", multiValued: true);
+                Assert.True(a.multiValued);
+            }
+
+            [Fact]
+            public void TwoStringsConstructor_OptionalMultiValuedIsFalse()
+            {
+                var a = new AzmiArgument("some-name", "some-description");
+                Assert.False(a.multiValued);
             }
         }
 

--- a/test/integration/blob-tests.sh
+++ b/test/integration/blob-tests.sh
@@ -46,6 +46,8 @@ BC=0; PREFIX="notExisting"
 test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblobs -c $CONTAINER_LB --prefix $PREFIX | wc -l" $BC
 BC=3; EXCLUDE="server2"
 test "listblobs finds $BC blobs excluding $EXCLUDE" assert.Equals "azmi listblobs -c $CONTAINER_LB --exclude $EXCLUDE | wc -l" $BC
+BC=1; EXCLUDE1="file1"; EXCLUDE2="file2"
+test "listblobs finds $BC blobs with multiple excludes $EXCLUDE" assert.Equals "azmi listblobs -c $CONTAINER_LB --exclude $EXCLUDE | wc -l" $BC
 
 
 testing class "getblob"

--- a/test/integration/blob-tests.sh
+++ b/test/integration/blob-tests.sh
@@ -47,7 +47,7 @@ test "listblobs finds $BC blobs with prefix $PREFIX" assert.Equals "azmi listblo
 BC=3; EXCLUDE="server2"
 test "listblobs finds $BC blobs excluding $EXCLUDE" assert.Equals "azmi listblobs -c $CONTAINER_LB --exclude $EXCLUDE | wc -l" $BC
 BC=1; EXCLUDE1="file1"; EXCLUDE2="file2"
-test "listblobs finds $BC blobs with multiple excludes $EXCLUDE" assert.Equals "azmi listblobs -c $CONTAINER_LB --exclude $EXCLUDE | wc -l" $BC
+test "listblobs finds $BC blobs with multiple excludes" assert.Equals "azmi listblobs -c $CONTAINER_LB --exclude $EXCLUDE1 --exclude $EXCLUDE2 | wc -l" $BC
 
 
 testing class "getblob"

--- a/test/integration/blob-tests.sh
+++ b/test/integration/blob-tests.sh
@@ -71,6 +71,8 @@ BC=0; PREFIX="notExisting"; rm -rf $DOWNLOAD_DIR
 test "getblobs downloads $BC blobs with prefix $PREFIX" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --prefix $PREFIX | wc -l" $BC
 BC=3; EXCLUDE="server2"; rm -rf $DOWNLOAD_DIR
 test "getblobs downloads $BC blobs excluding $EXCLUDE" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --exclude $EXCLUDE | grep Success | wc -l" $BC
+BC=1; EXCLUDE1="file1"; EXCLUDE2="file2"; rm -rf $DOWNLOAD_DIR
+test "getblobs downloads $BC blobs with multiple excludes" assert.Equals "azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --exclude $EXCLUDE1 --exclude $EXCLUDE2 | grep Success | wc -l" $BC
 
 
 testing class "setblob"


### PR DESCRIPTION
~~This should be merged after #177~~ Done

Adding new functionality for azmi options named **`bool multiValued`.**
It enables customers to use something like `--exclude value1 --exclude value2`.

Requires changes in implementation code:
- declaration: received object is now an array, something like `string[] exclude` instead of `string exclude`
- implementation:
  - instead of this `var rx = new Regex(exclude);`
  - we now have this `var rx = new Regex(String.Join('|',exclude));`

It is implemented for `--exclude` in `getblobs` and `listblobs` and it can be easily extended further. Unit testing and integration testing updated. Example from integration tests:
```shell
azmi listblobs -c $CONTAINER_LB --exclude $EXCLUDE1 --exclude $EXCLUDE2
azmi getblobs -c $CONTAINER_LB -d $DOWNLOAD_DIR --exclude $EXCLUDE1 --exclude $EXCLUDE2
```