### PR TITLE
switch back Core31

### DIFF
--- a/azmi-gui/azmi-gui.csproj
+++ b/azmi-gui/azmi-gui.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>azmi_gui</RootNamespace>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,1 @@
-./src/azmi-commandline/bin/Release/netcoreapp3.0/linux-x64/publish/azmi usr/bin/
+./src/azmi-commandline/bin/Release/netcoreapp3.1/linux-x64/publish/azmi usr/bin/

--- a/src/azmi-commandline/azmi-commandline.csproj
+++ b/src/azmi-commandline/azmi-commandline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>azmi_commandline</RootNamespace>
     <AssemblyName>azmi</AssemblyName>
     <ApplicationIcon />

--- a/src/azmi-main/azmi-main.csproj
+++ b/src/azmi-main/azmi-main.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>azmi_main</RootNamespace>
     <OutputType>Library</OutputType>
     <Version>0.5.0</Version>

--- a/test/azmi-main-tests/azmi-main-tests.csproj
+++ b/test/azmi-main-tests/azmi-main-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>azmi_tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/test/integration/integration-pipeline.sh
+++ b/test/integration/integration-pipeline.sh
@@ -8,7 +8,7 @@
 
 dotnet publish ./src/azmi-commandline/azmi-commandline.csproj --configuration Release --self-contained true /p:PublishSingleFile=true --runtime linux-x64
 
-exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.0/linux-x64/publish || exit; pwd)
+exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.1/linux-x64/publish || exit; pwd)
 export PATH="$exePath:$PATH"
 export DOTNET_BUNDLE_EXTRACT_BASE_DIR="$HOME/cache_dotnet_bundle_extract"
 

--- a/test/performance/1-basic-tests.sh
+++ b/test/performance/1-basic-tests.sh
@@ -6,8 +6,7 @@ echo 'azmi - build executable'
 # dotnet build src/azmi-commandline/azmi-commandline.csproj
 dotnet publish ./src/azmi-commandline/azmi-commandline.csproj --configuration Release --self-contained true /p:PublishSingleFile=true --runtime linux-x64
 
-#exePath=$(cd ./src/azmi-commandline/bin/Debug/netcoreapp3.0 || exit; pwd)
-exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.0/linux-x64/publish || exit; pwd)
+exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.1/linux-x64/publish || exit; pwd)
 export PATH="$exePath:$PATH"
 export DOTNET_BUNDLE_EXTRACT_BASE_DIR="$HOME/cache_dotnet_bundle_extract"
 

--- a/test/performance/2-single-blob-tests.sh
+++ b/test/performance/2-single-blob-tests.sh
@@ -7,8 +7,7 @@ echo 'azmi - build executable'
 # dotnet build src/azmi-commandline/azmi-commandline.csproj
 dotnet publish ./src/azmi-commandline/azmi-commandline.csproj --configuration Release --self-contained true /p:PublishSingleFile=true --runtime linux-x64
 
-#exePath=$(cd ./src/azmi-commandline/bin/Debug/netcoreapp3.0 || exit; pwd)
-exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.0/linux-x64/publish || exit; pwd)
+exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.1/linux-x64/publish || exit; pwd)
 export PATH="$exePath:$PATH"
 export DOTNET_BUNDLE_EXTRACT_BASE_DIR="$HOME/cache_dotnet_bundle_extract"
 

--- a/test/performance/3-multiple-blobs-tests.sh
+++ b/test/performance/3-multiple-blobs-tests.sh
@@ -4,8 +4,7 @@ echo 'azmi - build executable'
 # dotnet build src/azmi-commandline/azmi-commandline.csproj
 dotnet publish ./src/azmi-commandline/azmi-commandline.csproj --configuration Release --self-contained true /p:PublishSingleFile=true --runtime linux-x64
 
-#exePath=$(cd ./src/azmi-commandline/bin/Debug/netcoreapp3.0 || exit; pwd)
-exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.0/linux-x64/publish || exit; pwd)
+exePath=$(cd ./src/azmi-commandline/bin/Release/netcoreapp3.1/linux-x64/publish || exit; pwd)
 export PATH="$exePath:$PATH"
 export DOTNET_BUNDLE_EXTRACT_BASE_DIR="$HOME/cache_dotnet_bundle_extract"
 


### PR DESCRIPTION
Resolves #182 

We switched to dotnet core 3.0 because it was not supported in pipelines
In mean time, it ran out of support
This PR is switching back to dotnet core 3.1