### PR TITLE
Unit tests inject in constructor

### DIFF
--- a/src/azmi-main/blob/BlobClientImpl.cs
+++ b/src/azmi-main/blob/BlobClientImpl.cs
@@ -16,10 +16,24 @@ namespace azmi_main
             blobClient = new BlobClient(blobUri, credential);
         }
 
-
         public Response<BlobContentInfo> Upload(string path, bool overwrite = false)
         {
-            return this.blobClient.Upload(path, overwrite);
+            return blobClient.Upload(path, overwrite);
+        }
+
+        public Response Delete()
+        {
+            return blobClient.Delete();
+        }
+
+        public Response DownloadTo(string path)
+        {
+            return blobClient.DownloadTo(path);
+        }
+
+        public Response<BlobProperties> GetProperties()
+        {
+            return blobClient.GetProperties();
         }
     }
 }

--- a/src/azmi-main/blob/GetBlob.cs
+++ b/src/azmi-main/blob/GetBlob.cs
@@ -3,14 +3,27 @@ using System.IO;
 using System.Collections.Generic;
 
 using Azure.Identity;
-using Azure.Storage.Blobs;
 
 namespace azmi_main
 {
     public class GetBlob : IAzmiCommand
     {
+        private IBlobClient blobClient { get; set; }
+
         //
-        // Declare command elements
+        //  Constructors
+        //
+
+        public GetBlob() { }
+
+        public GetBlob(IBlobClient blobClientMock)
+        {
+            blobClient = blobClientMock;
+        }
+
+
+        //
+        //  Declare command elements
         //
 
         public SubCommandDefinition Definition()
@@ -68,7 +81,7 @@ namespace azmi_main
 
             // Connection
             var Cred = new ManagedIdentityCredential(identity);
-            var blobClient = new BlobClient(new Uri(blobURL), Cred);
+            blobClient ??= new BlobClientImpl(new Uri(blobURL), Cred);
 
             if (ifNewer && File.Exists(filePath) && !IsNewer(blobClient, filePath))
             {
@@ -98,7 +111,7 @@ namespace azmi_main
             }
         }
 
-        private bool IsNewer(BlobClient blob, string filePath)
+        private bool IsNewer(IBlobClient blob, string filePath)
         {
             var blobProperties = blob.GetProperties();
             // Any operation that modifies a blob, including an update of the blob's metadata or properties, changes the last modified time of the blob

--- a/src/azmi-main/blob/IBlobClient.cs
+++ b/src/azmi-main/blob/IBlobClient.cs
@@ -7,5 +7,8 @@ namespace azmi_main
     public interface IBlobClient
     {
         Response<BlobContentInfo> Upload(string path, bool overwrite = false);
+        Response DownloadTo(string path);
+        Response Delete();
+        Response<BlobProperties> GetProperties();
     }
 }

--- a/src/azmi-main/blob/SetBlob.cs
+++ b/src/azmi-main/blob/SetBlob.cs
@@ -8,7 +8,6 @@ namespace azmi_main
     {
         private IBlobClient blobClient { get; set; }
 
-
         //
         //  Constructors
         //
@@ -22,7 +21,7 @@ namespace azmi_main
 
 
         //
-        //  SubCommand Definition
+        //  Declare command elements
         //
 
         public SubCommandDefinition Definition()
@@ -60,7 +59,8 @@ namespace azmi_main
             try
             {
                 opt = (AzmiArgumentsClass)options;
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 throw AzmiException.WrongObject(ex);
             }
@@ -81,7 +81,8 @@ namespace azmi_main
             {
                 blobClient.Upload(filePath, force);
                 return "Success";
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 throw AzmiException.IDCheck(identity, ex);
             }

--- a/src/azmi-main/blob/SetBlob.cs
+++ b/src/azmi-main/blob/SetBlob.cs
@@ -6,8 +6,28 @@ namespace azmi_main
 {
     public class SetBlob : IAzmiCommand
     {
+        private IBlobClient blobClient { get; set; }
+
+
+        //
+        //  Constructors
+        //
+
+        public SetBlob() { }
+
+        public SetBlob(IBlobClient blobClientMock)
+        {
+            blobClient = blobClientMock;
+        }
+
+
+        //
+        //  SubCommand Definition
+        //
+
         public SubCommandDefinition Definition()
         {
+
             return new SubCommandDefinition
             {
 
@@ -52,8 +72,7 @@ namespace azmi_main
         // Execute SetBlob
         //
 
-        public string Execute(string filePath, string blobUri, string identity = null, bool force = false,
-            IBlobClient blobClient = null)
+        public string Execute(string filePath, string blobUri, string identity = null, bool force = false)
         {
             var Cred = new ManagedIdentityCredential(identity);
             blobClient ??= new BlobClientImpl(new Uri(blobUri), Cred);

--- a/test/azmi-main-tests/azmi-main-tests.csproj
+++ b/test/azmi-main-tests/azmi-main-tests.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.1.0">
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+	  <PackageReference Include="coverlet.collector" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/azmi-main-tests/blob/GetBlob-Tests.cs
+++ b/test/azmi-main-tests/blob/GetBlob-Tests.cs
@@ -89,7 +89,6 @@ namespace azmi_tests
             [Fact]
             public void FailsWithExistingProperty()
             {
-                
                 // Arrange
                 var obj = new GetBlob.AzmiArgumentsClass
                 {
@@ -98,9 +97,9 @@ namespace azmi_tests
                     ifNewer = false,
                     deleteAfterCopy = false,
                     identity = _identity,
-                    verbose = false                    
+                    verbose = false
                 };
-                
+
                 var blobSubstitute = Substitute.For<IBlobClient>();
                 blobSubstitute.DownloadTo(_anyGoodPath).Returns(_nullResponse);
                 var subCommand = new GetBlob(blobSubstitute);

--- a/test/azmi-main-tests/blob/GetBlob-Tests.cs
+++ b/test/azmi-main-tests/blob/GetBlob-Tests.cs
@@ -1,0 +1,224 @@
+﻿using azmi_main;
+using Azure;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace azmi_tests
+{
+    public class GetBlob_Tests
+    {
+        [Fact]
+        public void DummyTest()
+        {
+            Assert.True(true);
+        }
+
+        public class SharedArguments_TestsGroup
+        {
+            [Fact]
+            public void IdentityArgument()
+            {
+                var subCommand = new GetBlob();
+                var arguments = subCommand.Definition().arguments;
+                Assert.NotEmpty(arguments.Where(a => a.name == SharedAzmiArguments.identity.name));
+            }
+
+            [Fact]
+            public void VerboseArgument()
+            {
+                var subCommand = new GetBlob();
+                var arguments = subCommand.Definition().arguments;
+                Assert.NotEmpty(arguments.Where(a => a.name == SharedAzmiArguments.verbose.name));
+            }
+        }
+
+        public class RealArguments_TestsGroup
+        {
+            // test if it has real arguments we defined, prevents accidental argument removal
+            [Theory]
+            [InlineData("blob")]
+            [InlineData("file")]
+            [InlineData("if-newer")]
+            [InlineData("delete-after-copy")]
+            public void TestRealArguments(string argName)
+            {
+                // Arrange
+                var subCommand = new GetBlob();
+                // Act
+                var arguments = subCommand.Definition().arguments;
+                // Assert
+                Assert.NotEmpty(arguments.Where(a => a.name == argName));
+            }
+
+            [Fact]
+            public void NoFakeArgument()
+            {
+                var subCommand = new GetBlob();
+                var arguments = subCommand.Definition().arguments;
+                Assert.Empty(arguments.Where(a => a.name == "fakeArgument"));
+            }
+        }
+        public class GenericExecute_TestsGroup
+        {
+            private readonly string _anyGoodPath = "a.txt";
+            private readonly string _identity = "123";
+            private readonly string _anyValidURL = "https://www.example.com";
+            private readonly bool _force = false;
+            private readonly string _failMsg = "Cannot convert input object to proper class";
+            private readonly Response _nullResponse = null;
+
+            // test if it will call real execute method
+            [Fact]
+            public void FailsWithNonExistingProperty()
+            {
+                var obj = new { nonExistingProperty = 1 };
+                var subCommand = new GetBlob();
+
+                // it throws exception
+                var actualExc = Assert.Throws<AzmiException>(() =>
+                   subCommand.Execute(obj)
+                );
+                Assert.Equal(_failMsg, actualExc.Message);
+            }
+
+            // TODO: Add test that will fail with existing property, but with different exception than above
+            [Fact]
+            public void FailsWithExistingProperty()
+            {
+                
+                // Arrange
+                var obj = new GetBlob.AzmiArgumentsClass
+                {
+                    file = _anyGoodPath,
+                    blob = _anyValidURL,
+                    ifNewer = false,
+                    deleteAfterCopy = false,
+                    identity = _identity,
+                    verbose = false                    
+                };
+                
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Returns(_nullResponse);
+                var subCommand = new GetBlob(blobSubstitute);
+
+                // Act and Assert
+                var retValue = subCommand.Execute(obj);
+                Assert.Equal("Success", retValue.First());
+                blobSubstitute.DidNotReceive().Delete();
+            }
+        }
+
+
+        //
+        // main tests
+        //
+
+        public class GetBlobExecute_TestsGroup
+        {
+            // mock DownloadTo method to return success or failure and check SetBlob status
+            private readonly string _anyGoodPath = "a.txt";
+            private readonly string _identity = "123";
+            private readonly string _anyValidURL = "https://www.example.com";
+            private readonly Response _nullResponse = null;
+            private readonly Exception _testException = new Exception("testing exception");
+            private readonly Exception _testAzureException = new Azure.RequestFailedException("testing Azure exception");
+
+            [Fact]
+            public void ExecutedWithSuccess()
+            {
+                // mock with success
+
+                // Arrange
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Returns(_nullResponse);
+                var subCommand = new GetBlob(blobSubstitute);
+                // Act
+                var retValue = subCommand.Execute(_anyValidURL, _anyGoodPath, _identity, false, false);
+                // Assert
+                Assert.Equal("Success", retValue);
+                blobSubstitute.DidNotReceive().Delete();
+            }
+
+            [Fact]
+            public void ExecutedWithFailure_WithIdentity()
+            {
+                // mock with exception and call with identity
+
+                // Arrange
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Throws(_testException);
+                var subCommand = new GetBlob(blobSubstitute);
+                // Act & Assert
+                var actualExc = Assert.Throws<Exception>(
+                    () => subCommand.Execute(_anyValidURL, _anyGoodPath, _identity, false, false)
+                );
+                Assert.Equal(_testException.Message, actualExc.Message);
+            }
+
+            [Fact]
+            public void ExecutedWithFailure_NoIdentity()
+            {
+                // mock with exception and call without identity
+
+                // Arrange
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Throws(_testException);
+                var subCommand = new GetBlob(blobSubstitute);
+                // Act & Assert
+                var actualExc = Assert.Throws<AzmiException>(
+                    () => subCommand.Execute(_anyValidURL, _anyGoodPath, null)
+                );
+                Assert.Equal(_testException.Message, actualExc.InnerException.Message);
+            }
+
+            [Fact]
+            public void ExecutedWithAzureFailure()
+            {
+                // mock with exception and call without identity
+
+                // Arrange
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Throws(_testAzureException);
+                var subCommand = new GetBlob(blobSubstitute);
+                // Act & Assert
+                var actualExc = Assert.Throws<RequestFailedException>(
+                    () => subCommand.Execute(_anyValidURL, _anyGoodPath, null)
+                );
+                Assert.Equal(_testAzureException.Message, actualExc.Message);
+            }
+
+            [Fact]
+            public void DeleteAfterCopyShouldBeCalled()
+            {
+                // Arrange
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Returns(_nullResponse);
+                var subCommand = new GetBlob(blobSubstitute);
+                // Act & Assert
+                subCommand.Execute(_anyValidURL, _anyGoodPath, _identity, deleteAfterCopy: true);
+                blobSubstitute.Received().Delete();
+            }
+
+            [Fact]
+            public void IfNewer_IgnoredForNotExistingFile()
+            {
+                // Arrange
+                var blobSubstitute = Substitute.For<IBlobClient>();
+                blobSubstitute.DownloadTo(_anyGoodPath).Returns(_nullResponse);
+                var subCommand = new GetBlob(blobSubstitute);
+                // Act & Assert
+                var retValue = subCommand.Execute(_anyValidURL, _anyGoodPath, _identity, ifNewer: true);
+                Assert.NotEqual("Skipped", retValue);
+            }
+
+            // TODO: Add two more tests:
+            // - IfNewer_IgnoredForNewerFile, returns Success
+            // - IfNewer_AppliedForOlderFile, returns Skipped
+
+        }
+    }
+}

--- a/test/azmi-main-tests/blob/SetBlob-Tests.cs
+++ b/test/azmi-main-tests/blob/SetBlob-Tests.cs
@@ -1,12 +1,12 @@
 ﻿using azmi_main;
-using System.Linq;
-using Xunit;
-using NSubstitute;
-using Azure.Storage.Blobs.Models;
 using Azure;
+using Azure.Storage.Blobs.Models;
+using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using System;
 using System.IO;
+using System.Linq;
+using Xunit;
 
 namespace azmi_tests
 {
@@ -25,7 +25,7 @@ namespace azmi_tests
             {
                 var subCommand = new SetBlob();
                 var arguments = subCommand.Definition().arguments;
-                Assert.NotNull(arguments.Select(a => a.name == SharedAzmiArguments.identity.name));
+                Assert.NotEmpty(arguments.Where(a => a.name == SharedAzmiArguments.identity.name));
             }
 
             [Fact]
@@ -33,23 +33,44 @@ namespace azmi_tests
             {
                 var subCommand = new SetBlob();
                 var arguments = subCommand.Definition().arguments;
-                Assert.NotNull(arguments.Select(a => a.name == SharedAzmiArguments.verbose.name));
+                Assert.NotEmpty(arguments.Where(a => a.name == SharedAzmiArguments.verbose.name));
             }
         }
 
         public class RealArguments_TestsGroup
         {
-            // test if it has proper arguments we defined
+            // test if it has real arguments we defined, prevents accidental argument removal
+            [Theory]
+            [InlineData("file")]
+            [InlineData("blob")]
+            [InlineData("force")]
+            public void TestRealArguments(string argName)
+            {
+                // Arrange
+                var subCommand = new SetBlob();
+                // Act
+                var arguments = subCommand.Definition().arguments;
+                // Assert
+                Assert.NotEmpty(arguments.Where(a => a.name == argName));
+            }
+
+            [Fact]
+            public void NoFakeArgument()
+            {
+                var subCommand = new SetBlob();
+                var arguments = subCommand.Definition().arguments;
+                Assert.Empty(arguments.Where(a => a.name == "fakeArgument"));
+            }
+
         }
 
         public class GenericExecute_TestsGroup
         {
-            private readonly string _path = "a.txt";
+            private readonly string _anyGoodPath = "a.txt";
             private readonly string _identity = "123";
-            private readonly string _url = "https://www.example.com";
+            private readonly string _anyValidURL = "https://www.example.com";
             private readonly bool _force = false;
             private readonly string _failMsg = "Cannot convert input object to proper class";
-            private readonly Response<BlobContentInfo> _bci = null;
 
             // test if it will call real execute method
             [Fact]
@@ -70,8 +91,8 @@ namespace azmi_tests
             {
                 var obj = new SetBlob.AzmiArgumentsClass
                 {
-                    file = _path,
-                    blob = _url,
+                    file = _anyGoodPath,
+                    blob = _anyValidURL,
                     force = _force,
                     identity = _identity,
                     verbose = false
@@ -83,7 +104,7 @@ namespace azmi_tests
                     () => subCommand.Execute(obj)
                 );
                 Assert.NotEqual(_failMsg, actualExc.Message);
-                Assert.Contains(_path, actualExc.Message);
+                Assert.Contains(_anyGoodPath, actualExc.Message);
             }
         }
 
@@ -96,24 +117,23 @@ namespace azmi_tests
         {
             // mock Upload method to return success or failure and check SetBlob status
 
-            // setup fake variables, easier that using Any constructs
-            private readonly string _path = "a.txt";
+            // setup fake variables, easier than using Any constructs
+            private readonly string _anyGoodPath = "a.txt";
             private readonly string _identity = "123";
-            private readonly string _url = "https://www.example.com";
-            private readonly bool _force= false;
-            private readonly Exception _exception = new Exception("testing exception");
+            private readonly string _anyValidURL = "https://www.example.com";
+            private readonly bool _force = false;
+            private readonly Exception _testException = new Exception("testing exception");
             private readonly Response<BlobContentInfo> _bci = null;
-
 
             [Fact]
             public void ExecutedWithSuccess()
             {
                 // mock with success
                 var blobSubstitute = Substitute.For<IBlobClient>();
-                blobSubstitute.Upload(_path, _force).Returns(_bci);
+                blobSubstitute.Upload(_anyGoodPath, _force).Returns(_bci);
                 var subCommand = new SetBlob(blobSubstitute);
 
-                var retValue = subCommand.Execute(_path, _url, _identity, _force);
+                var retValue = subCommand.Execute(_anyGoodPath, _anyValidURL, _identity, _force);
                 Assert.Equal("Success", retValue);
 
             }
@@ -123,14 +143,14 @@ namespace azmi_tests
             {
                 // mock with exception and call with identity
                 var blobSubstitute = Substitute.For<IBlobClient>();
-                blobSubstitute.Upload(_path, _force).Throws(_exception);
+                blobSubstitute.Upload(_anyGoodPath, _force).Throws(_testException);
                 var subCommand = new SetBlob(blobSubstitute);
 
                 // it returns testing exception
                 var actualExc = Assert.Throws<Exception>(
-                    () => subCommand.Execute(_path, _url, _identity, _force)
+                    () => subCommand.Execute(_anyGoodPath, _anyValidURL, _identity, _force)
                 );
-                Assert.Equal(_exception.Message, actualExc.Message);
+                Assert.Equal(_testException.Message, actualExc.Message);
             }
 
             [Fact]
@@ -138,14 +158,14 @@ namespace azmi_tests
             {
                 // mock with exception and call with no identity
                 var blobSubstitute = Substitute.For<IBlobClient>();
-                blobSubstitute.Upload(_path, _force).Throws(_exception);
+                blobSubstitute.Upload(_anyGoodPath, _force).Throws(_testException);
                 var subCommand = new SetBlob(blobSubstitute);
 
                 // it returns Azmi exception and testing one as inner
                 var actualExc = Assert.Throws<AzmiException>(
-                    () => subCommand.Execute(_path, _url, null, _force)
+                    () => subCommand.Execute(_anyGoodPath, _anyValidURL, null, _force)
                 );
-                Assert.Equal(_exception.Message, actualExc.InnerException.Message);
+                Assert.Equal(_testException.Message, actualExc.InnerException.Message);
 
             }
         }

--- a/test/azmi-main-tests/blob/SetBlob-Tests.cs
+++ b/test/azmi-main-tests/blob/SetBlob-Tests.cs
@@ -111,9 +111,9 @@ namespace azmi_tests
                 // mock with success
                 var blobSubstitute = Substitute.For<IBlobClient>();
                 blobSubstitute.Upload(_path, _force).Returns(_bci);
-                var subCommand = new SetBlob();
+                var subCommand = new SetBlob(blobSubstitute);
 
-                var retValue = subCommand.Execute(_path, _url, _identity, _force, blobSubstitute);
+                var retValue = subCommand.Execute(_path, _url, _identity, _force);
                 Assert.Equal("Success", retValue);
 
             }
@@ -124,11 +124,11 @@ namespace azmi_tests
                 // mock with exception and call with identity
                 var blobSubstitute = Substitute.For<IBlobClient>();
                 blobSubstitute.Upload(_path, _force).Throws(_exception);
-                var subCommand = new SetBlob();
+                var subCommand = new SetBlob(blobSubstitute);
 
                 // it returns testing exception
                 var actualExc = Assert.Throws<Exception>(
-                    () => subCommand.Execute(_path, _url, _identity, _force, blobSubstitute)
+                    () => subCommand.Execute(_path, _url, _identity, _force)
                 );
                 Assert.Equal(_exception.Message, actualExc.Message);
             }
@@ -139,11 +139,11 @@ namespace azmi_tests
                 // mock with exception and call with no identity
                 var blobSubstitute = Substitute.For<IBlobClient>();
                 blobSubstitute.Upload(_path, _force).Throws(_exception);
-                var subCommand = new SetBlob();
+                var subCommand = new SetBlob(blobSubstitute);
 
                 // it returns Azmi exception and testing one as inner
                 var actualExc = Assert.Throws<AzmiException>(
-                    () => subCommand.Execute(_path, _url, null, _force, blobSubstitute)
+                    () => subCommand.Execute(_path, _url, null, _force)
                 );
                 Assert.Equal(_exception.Message, actualExc.InnerException.Message);
 


### PR DESCRIPTION
Implemented unit testing in two commands:
- `getblob` - code coverage 76% _(52 blocks covered : 16 not covered)_, and
- `setblob` - coverage 93%, _(38 covered  :3 not covered)_

Main change is that unit testing is now using constuctor with one argument - mocked blob client class, something like
```cs
var subCommand = new GetBlob(blobSubstitute);
```

It required new methods in `BlobClientImpl` class and `IBlobClient` interface.

Tests are devided in couple of test groups:
- arguments tests - (shared and real ones) - those verify if proper arguments are present in command and fake are not - it prevents accidental removal of arguments
- generic execute method tests - with object as input argument - verifies if it calls properly real class execute method
- main tests which verify actual functionality of the class - those are heavily using mocked `BlobClient` class


Total number of unit tests is now 💯! There are 27 command line tests and 73 azmi main tests. [Unit testing](https://dev.azure.com/iiric/azmi/_build/results?buildId=2204) is successful. 

Integration tests (99 of them) were not modified and [it is still running fine](https://dev.azure.com/iiric/azmi/_build/results?buildId=2205).

One possible improvement is recorded in issue #194. In next days I will continue to implement the same functionality in other blob commands and later in other non-blob commands.

Resolves #196 